### PR TITLE
Fixed Bug with Incorrect Starting Date on Creating Commons Form

### DIFF
--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -70,7 +70,8 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     
     const testid = "CommonsForm";
     const curr = new Date();
-    const today = curr.toISOString().split('T')[0];
+    const localTime = new Date(curr.getTime() - curr.getTimezoneOffset() * 60000);
+    const today = localTime.toISOString().split('T')[0];
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const DefaultVals = {

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -3,6 +3,7 @@ import {useForm} from "react-hook-form";
 import {useBackend} from "main/utils/useBackend";
 import { useEffect } from "react";
 import HealthUpdateStrategiesDropdown from "main/components/Commons/HealthStrategiesUpdateDropdown";
+import { makeCommonsStartEndDate } from "main/utils/dateUtils";
 
 function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     let modifiedCommons = initialCommons ? { ...initialCommons } : {};  // make a shallow copy of initialCommons
@@ -69,11 +70,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     // Stryker restore all
     
     const testid = "CommonsForm";
-    const curr = new Date();
-    const localTime = new Date(curr.getTime() - curr.getTimezoneOffset() * 60000);
-    const today = localTime.toISOString().split('T')[0];
-    const currMonth = curr.getMonth() % 12;
-    const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
+    const [today, nextMonth] = makeCommonsStartEndDate();
     const DefaultVals = {
         name: "",
         startingBalance: defaultValuesData?.startingBalance || "10000",

--- a/frontend/src/main/utils/dateUtils.js
+++ b/frontend/src/main/utils/dateUtils.js
@@ -57,7 +57,7 @@ export function makeCommonsStartEndDate () {
     const currMonth = localTime.getMonth() % 12;
     const nextMonth = new Date(localTime.getFullYear(), currMonth + 1, localTime.getDate()).toISOString().substr(0, 10);
 
-    return today, nextMonth
+    return [today, nextMonth];
 
 }
 

--- a/frontend/src/main/utils/dateUtils.js
+++ b/frontend/src/main/utils/dateUtils.js
@@ -49,4 +49,16 @@ export function formatTime(timeString) {
     return dateFromEpoch.toLocaleDateString();
 }
 
+export function makeCommonsStartEndDate () {
+
+    const curr = new Date();
+    const localTime = new Date(curr.getTime() - curr.getTimezoneOffset() * 60000);
+    const today = localTime.toISOString().split('T')[0];
+    const currMonth = localTime.getMonth() % 12;
+    const nextMonth = new Date(localTime.getFullYear(), currMonth + 1, localTime.getDate()).toISOString().substr(0, 10);
+
+    return today, nextMonth
+
+}
+
 export {timestampToDate, padWithZero, daysSinceTimestamp};

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -154,7 +154,8 @@ describe("CommonsForm tests", () => {
   it("Check Default Values and correct styles", async () => {
 
     const curr = new Date();
-    const today = curr.toISOString().substr(0, 10);
+    const localTime = new Date(curr.getTime() - curr.getTimezoneOffset() * 60000);
+    const today = localTime.toISOString().split('T')[0];
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const DefaultVals = {
@@ -288,7 +289,8 @@ describe("CommonsForm tests", () => {
 
   it("renders correctly when an initialCommons is not passed in", async () => {
     const curr = new Date();
-    const today = curr.toISOString().substr(0, 10);
+    const localTime = new Date(curr.getTime() - curr.getTimezoneOffset() * 60000);
+    const today = localTime.toISOString().split('T')[0];
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const DefaultVals = {
@@ -360,7 +362,8 @@ test("the correct parameters are passed to useBackend", async () => {
   test("populates form fields with default values when initialCommons is not provided", async () => {
 
     const curr = new Date();
-    const today = curr.toISOString().substr(0, 10);
+    const localTime = new Date(curr.getTime() - curr.getTimezoneOffset() * 60000);
+    const today = localTime.toISOString().split('T')[0];
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const defaultValuesData = {

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -6,6 +6,7 @@ import commonsFixtures from "fixtures/commonsFixtures"
 import AxiosMockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import healthUpdateStrategyListFixtures from "fixtures/healthUpdateStrategyListFixtures";
+import { makeCommonsStartEndDate } from "main/utils/dateUtils";
 
 // Next line uses technique from https://www.chakshunyu.com/blog/how-to-spy-on-a-named-import-in-jest/
 import * as useBackendModule from "main/utils/useBackend";
@@ -153,11 +154,7 @@ describe("CommonsForm tests", () => {
 
   it("Check Default Values and correct styles", async () => {
 
-    const curr = new Date();
-    const localTime = new Date(curr.getTime() - curr.getTimezoneOffset() * 60000);
-    const today = localTime.toISOString().split('T')[0];
-    const currMonth = curr.getMonth() % 12;
-    const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
+    const [today, nextMonth] = makeCommonsStartEndDate();
     const DefaultVals = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth
@@ -288,11 +285,8 @@ describe("CommonsForm tests", () => {
   });
 
   it("renders correctly when an initialCommons is not passed in", async () => {
-    const curr = new Date();
-    const localTime = new Date(curr.getTime() - curr.getTimezoneOffset() * 60000);
-    const today = localTime.toISOString().split('T')[0];
-    const currMonth = curr.getMonth() % 12;
-    const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
+
+    const [today, nextMonth] = makeCommonsStartEndDate();
     const DefaultVals = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth, aboveCapacityStrategy: "Linear", belowCapacityStrategy: "Constant"
@@ -361,11 +355,7 @@ test("the correct parameters are passed to useBackend", async () => {
 
   test("populates form fields with default values when initialCommons is not provided", async () => {
 
-    const curr = new Date();
-    const localTime = new Date(curr.getTime() - curr.getTimezoneOffset() * 60000);
-    const today = localTime.toISOString().split('T')[0];
-    const currMonth = curr.getMonth() % 12;
-    const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
+    const [today, nextMonth] = makeCommonsStartEndDate();
     const defaultValuesData = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth

--- a/frontend/src/tests/utils/dateUtils.test.js
+++ b/frontend/src/tests/utils/dateUtils.test.js
@@ -1,4 +1,4 @@
-import { padWithZero, timestampToDate, daysSinceTimestamp, formatTime } from "main/utils/dateUtils";
+import { padWithZero, timestampToDate, daysSinceTimestamp, formatTime, makeCommonsStartEndDate } from "main/utils/dateUtils";
 
 
 describe("dateUtils tests", () => {
@@ -72,4 +72,18 @@ describe("dateUtils tests", () => {
       expect(formatTime(twoWeeksAgo.toISOString())).toEqual(twoWeeksAgo.toLocaleDateString());
     });
   })
+
+  describe ("makeCommonsStartEndDate tests", () => {
+
+    it('correctly creates the start and end date for troublsome times', () => {
+      jest.useFakeTimers().setSystemTime(new Date('2022-05-31T21:00:00'));
+      const [today, nextMonth] = makeCommonsStartEndDate();
+    
+      expect(today).toBe('2022-05-31');
+      expect(nextMonth).toBe('05');
+      
+      jest.useRealTimers();
+    });
+
+  });
 });

--- a/frontend/src/tests/utils/dateUtils.test.js
+++ b/frontend/src/tests/utils/dateUtils.test.js
@@ -76,11 +76,11 @@ describe("dateUtils tests", () => {
   describe ("makeCommonsStartEndDate tests", () => {
 
     it('correctly creates the start and end date for troublsome times', () => {
-      jest.useFakeTimers().setSystemTime(new Date('2022-05-31T21:00:00'));
+      jest.useFakeTimers().setSystemTime(new Date('2022-06-30T21:00:00'));
       const [today, nextMonth] = makeCommonsStartEndDate();
     
-      expect(today).toBe('2022-05-31');
-      expect(nextMonth).toBe('05');
+      expect(today).toBe('2022-06-30');
+      expect(nextMonth).toBe('2022-07-30');
       
       jest.useRealTimers();
     });


### PR DESCRIPTION
## Overview
In this PR, I fixed the autofilled date in the Starting Date field of the form when creating a commons to accurately reflect the current day's date.

The cause of the bug was using `.toISOString().split('T')[0]` on the date object that filled in the field. When the object was initially created it was made according to local time, but by using that function it converts it into UTC time which is 8 hours ahead which led to the start date having tomorrows date. Those numbers are because our current timezone, PDT, is UTC-8 (meaning 8 hours behind UTC 0). The functions used to fix the bug work for different time zones, not just PDT.

I fixed this bug by adjusting the initial date object to be 8 hours before local time which counteracts the time conversion when using the function which results in a final date object that accurately reflects local time.

Date object function documentation: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString

After instructor request, I also moved the creation of the `today` and `nextMonth` variable which is assigned into `startingDate` and `lastDate` respectively on the form into a function called `makeCommonsStartEndDate` in `dateUtils.js`. The 4 instances of those variables being created (1 in `CommonsForm.js`, 3 in `CommonsForm.test.js`) have been replaced by a call to that function.

## Feedback Request 
Please give suggestions on the following:
- There is also another method that avoids .toISOString() entirely that manually displays the date in the correct format which I chose not to do since it was tedious, is the method I used alright?

## Validation 
1. Pull the branch locally and run on localhost **OR** go to my personal dokku here: https://happycows-garvinyoung-dev.dokku-05.cs.ucsb.edu/
2. Login using an admin email and navigate to the Admin dropdown menu on the navigation bar and select Create Commons
3. Look at the "Starting Date" field to see if the date is correct, to test different dates I change the time and date on my laptop which works but runs into some issues such as the login expiring if changing dates/times into the future.

## Tests
This was a very simple issue so I just tested it by using localhost and changing the date and time on my laptop. I used 5/10/2024 3:30pm and 5/10/2024 4:30pm. Before the fix the start date would be 5/10/2024 for the former and 5/11/2024 for the latter, with the updated code it is now 5/10/2024 for both.

~~I didn't make any new tests, just changed the existing tests in CommonsForm.test.js to correctly set the Starting Date so all tests pass.~~

The creation of the function didn't require any change to existing tests, but did require a test in `dateUtils.test.js` to test functionality. It tests 6/30 9pm, if the bug is still present the start date would roll over to 7/1 which then causes the end date to be 8/1. The current expect statements check if the bug is correctly eliminated and they pass.

## Linked Issues
Closes #4 