### PR TITLE
Issue F2: Add Announcement Button to Admin Commons List

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,6 +19,7 @@ import { hasRole, useCurrentUser } from "main/utils/currentUser";
 import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
 import AdminViewPlayPage from "main/pages/AdminViewPlayPage";
+import AdminAnnouncementsPage from "main/pages/AdminAnnouncementsPage";
 
 function App() {
     const { data: currentUser } = useCurrentUser();
@@ -47,6 +48,10 @@ function App() {
             <Route
                 path="/admin/play/:commonsId/user/:userId"
                 element={<AdminViewPlayPage />}
+            />
+            <Route
+                path="/admin/announcements/:commonsId"
+                element={<AdminAnnouncementsPage />}
             />
         </>
     ) : null;

--- a/frontend/src/main/components/Commons/CommonsTable.js
+++ b/frontend/src/main/components/Commons/CommonsTable.js
@@ -117,6 +117,7 @@ export default function CommonsTable({ commons, currentUser }) {
         ButtonColumn("Delete", "danger", deleteCallback, testid),
         ButtonColumn("Leaderboard", "secondary", leaderboardCallback, testid),
         HrefButtonColumn("Stats CSV", "success", `/api/commonstats/download?commonsId=`, testid),
+        HrefButtonColumn("Announcements", "info", `/admin/announcements/`, testid),
     ];
 
     const columnsToDisplay = hasRole(currentUser,"ROLE_ADMIN") ? columnsIfAdmin : columns;

--- a/frontend/src/main/pages/AdminAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminAnnouncementsPage.js
@@ -1,0 +1,13 @@
+
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function AdminAnnouncementsPage() {
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Feature Coming Soon</h1>
+            </div>
+        </BasicLayout>
+    )
+}

--- a/frontend/src/tests/components/Commons/CommonsTable.test.js
+++ b/frontend/src/tests/components/Commons/CommonsTable.test.js
@@ -105,6 +105,7 @@ describe("UserTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-0-col-Delete-button`)).toHaveClass("btn-danger");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-Leaderboard-button`)).toHaveClass("btn-secondary");
     expect(screen.getByTestId(`${testId}-cell-row-0-col-Stats CSV-button`)).toHaveClass("btn-success");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-Announcements-button`)).toHaveClass("btn-info");
 
   });
 

--- a/frontend/src/tests/pages/AdminAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminAnnouncementsPage.test.js
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import AdminAnnouncementsPage from "main/pages/AdminAnnouncementsPage";
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+describe("AdminAnnouncement tests", () => {
+    const queryClient = new QueryClient();
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(()=>{
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    });
+
+    test("renders correctly without crashing", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminAnnouncementsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText("Feature Coming Soon")).toBeInTheDocument();
+    });
+
+});

--- a/frontend/src/tests/pages/AdminListCommonsPage.test.js
+++ b/frontend/src/tests/pages/AdminListCommonsPage.test.js
@@ -217,4 +217,25 @@ describe("AdminListCommonPage tests", () => {
         expect(statsCSVButton).toHaveAttribute("href", "/api/commonstats/download?commonsId=1");
 
     })
+
+    test("correct href for announcements button as an admin", async () => {
+        setupAdminUser();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/commons/allplus").reply(200, commonsPlusFixtures.threeCommonsPlus);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminListCommonPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByTestId(`${testId}-cell-row-0-col-commons.id`)).toHaveTextContent("1");
+      
+        const announcementButton = screen.getByTestId(`${testId}-cell-row-0-col-Announcements-button`);
+        expect(announcementButton).toHaveAttribute("href", "/admin/announcements/1");
+
+    })
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I added a button called 'Announcements' next to the current buttons on the Admin Commons List page. Once clicked, it will lead you to the url `/admin/announcements/{commonsId}` , which will state that it doesn't exist yet as it will be implemented in the next issue.

## Screenshots
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
![image](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/97550852/a2722e2a-25a3-495a-a11e-d19d5dcac329)

## Future Possibilities
<!--What do you think this project could become? Delete if not needed.-->
- This is the beginning/part of feature F2.
- We can extend this to add the index page for Announcements


## Validation
<!--Steps that someone else could take to make sure everything is working-->
1. Pull my branch and run on localhost or go to my dev: https://happycows-jasontnguyen-dev.dokku-05.cs.ucsb.edu/
2. Log in as an admin and either create a new common or go to the admin list to click the announcements button
3. Pressing the announcements button should lead you to a 404 but with the correct url in the search bar since the page isn't implemented yet.

## Tests
<!--Add any additional tests or required tests-->
- [x] Frontend Unit tests (`npm test`) pass
I created two additional tests that test whether the Announcements button shows up on the admin commons list and if it leads to the right url, which both tests pass.

## Linked Issues
<!--Issues related to the PR-->
Closes #27 
