### PR TITLE
SwaggerUILink Correctly Appears Depending on Corresponding Dokku Env Variable

### DIFF
--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -5,7 +5,7 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
-app.showSwaggerUILink=true
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-happycows}}
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application-integration.properties
+++ b/src/main/resources/application-integration.properties
@@ -5,7 +5,7 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
-app.showSwaggerUILink=true
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-happycows}}
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -1,5 +1,6 @@
 spring.datasource.url=${JDBC_DATABASE_URL}
 spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect

--- a/src/main/resources/application-wiremock.properties
+++ b/src/main/resources/application-wiremock.properties
@@ -5,7 +5,7 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
-app.showSwaggerUILink=true
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-happycows}}
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
@@ -28,7 +28,7 @@ class SystemInfoServiceImplTests  {
   void test_getSystemInfo() {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
-    assertTrue(si.getShowSwaggerUILink());
+    assertTrue(!si.getShowSwaggerUILink());
     assertEquals("https://github.com/ucsb-cs156/proj-happycows", si.getSourceRepo());
   }
 

--- a/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/services/SystemInfoServiceImplTests.java
@@ -2,6 +2,7 @@ package edu.ucsb.cs156.happiercows.services;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,7 +29,7 @@ class SystemInfoServiceImplTests  {
   void test_getSystemInfo() {
     SystemInfo si = systemInfoService.getSystemInfo();
     assertTrue(si.getSpringH2ConsoleEnabled());
-    assertTrue(!si.getShowSwaggerUILink());
+    assertFalse(si.getShowSwaggerUILink());
     assertEquals("https://github.com/ucsb-cs156/proj-happycows", si.getSourceRepo());
   }
 


### PR DESCRIPTION
## Overview
In this PR, we read the environmental variable `SHOW_SWAGGER_UI_LINK` on dokku and show "Swagger" on the main page navigation bar accordingly. If the variable is set to true, then it appears on the nav bar, if it is set to false or undefined, then it doesn't appear on the nav bar

## Screenshots
env variable set to true in left image, set to false or undefined in right image (both while logged into admin email)
![image](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/97640757/b1cb6a56-94f4-4edf-b810-f9189f2b1772)

## Future Possibilities
- A way to make this issue require more work which somewhat makes sense from a developer point of view is to have the swagger link behave the same way as the Admin dropdown menu also on the nav bar so normal users won't have access to it. The user story highlights how this issue is purely to help out the developer with clutter which makes it understandable why the aforementioned suggestion wouldn't be implemented since the env variable in prod would never be set to true anyways.

## Validation (my dokku is currently NOT syncd to this branch)
(Don't test on localhost, I couldn't figure out the exact problem, but localhost isn't affected by the env variable setting and seems to display Swagger and H2 Console regardless)
1. To reduce time to test, feel free to use my dokku app `happycows-garvinyoung-dev` since that is already sync'd to the branch of this pr
2. connect to dokku and set the environmental variable by using this command `dokku config:set --no-restart happycows-garvinyoung-dev SHOW_SWAGGER_UI_LINK=` filling in the end of the command with true or false
3. run `dokku config:show happycows-garvinyoung-dev` to ensure the env variable is defined and has the truth value you want
4. run `dokku ps:rebuild happycows-garvinyoung-dev` to implement the changes then go to the link: https://happycows-garvinyoung-dev.dokku-05.cs.ucsb.edu/ where you should see the correct display of "Swagger" on your nav bar depending on how you set the env variable

## Tests
Existing tests in `systemInfo.test.js` provides adequate coverage in testing the systemInfo object (which contains the boolean `showSwaggerUILink` which is assigned the value of the env variable `SHOW_SWAGGER_UI_LINK`) and existing tests in `AppNavbar.test.js` provides adequate coverage in testing functional rendering and correct display of "Swagger" on the nav bar according to the truth value of `showSwaggerUILink` in `systemInfoFixtures.js`.

You can tell that "Swagger" displaying is purely dependent on the truth values of `SHOW_SWAGGER_UI_LINK` through the validation steps

## Linked Issues
Closes #25
