### PR TITLE
Announcements Index Page Displaying the Correct Heading

### DIFF
--- a/frontend/src/main/pages/AdminAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminAnnouncementsPage.js
@@ -18,12 +18,12 @@ export default function AdminAnnouncementsPage() {
             },
         }
     );
-    const name = commonsPlus?.commons.name;
+    const commonsName = commonsPlus?.commons.name;
 
     return (
         <BasicLayout>
             <div className="pt-2">
-                <h1>Announcements for {name}</h1>
+                <h1>Announcements for {commonsName}</h1>
             </div>
         </BasicLayout>
     )

--- a/frontend/src/main/pages/AdminAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminAnnouncementsPage.js
@@ -1,13 +1,31 @@
 
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useBackend} from "main/utils/useBackend";
+import { useParams } from "react-router-dom";
 
 export default function AdminAnnouncementsPage() {
+    let { commonsId } = useParams();
+
+    // Stryker disable all
+    const { data: commonsPlus } = useBackend(
+        [`/api/commons/plus?id=${commonsId}`],
+        {
+            method: "GET",
+            url: "/api/commons/plus",
+            params: {
+                id: commonsId,
+            },
+        }
+    );
+    const name = commonsPlus?.commons.name;
+
     return (
         <BasicLayout>
             <div className="pt-2">
-                <h1>Feature Coming Soon</h1>
+                <h1>Announcements for {name}</h1>
             </div>
         </BasicLayout>
     )
+    
 }

--- a/frontend/src/tests/pages/AdminAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminAnnouncementsPage.test.js
@@ -7,8 +7,7 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import AdminAnnouncementsPage from "main/pages/AdminAnnouncementsPage";
 import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
-import commonsFixtures from "fixtures/commonsFixtures"; 
-import commonsPlusFixtures from "fixtures/commonsPlusFixtures";
+
 
 const mockNavigate = jest.fn();
 jest.mock("react-router-dom", () => ({

--- a/frontend/src/tests/pages/AdminAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminAnnouncementsPage.test.js
@@ -7,8 +7,19 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import AdminAnnouncementsPage from "main/pages/AdminAnnouncementsPage";
 import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import commonsFixtures from "fixtures/commonsFixtures"; 
+import commonsPlusFixtures from "fixtures/commonsPlusFixtures";
 
-describe("AdminAnnouncement tests", () => {
+const mockNavigate = jest.fn();
+jest.mock("react-router-dom", () => ({
+    ...jest.requireActual("react-router-dom"),
+    useParams: () => ({
+        commonsId: 1
+    }),
+    useNavigate: () => mockNavigate
+}));
+
+describe("AdminAnnouncementPage tests", () => {
     const queryClient = new QueryClient();
     const axiosMock = new AxiosMockAdapter(axios);
 
@@ -27,8 +38,26 @@ describe("AdminAnnouncement tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
+    });
 
-        expect(await screen.findByText("Feature Coming Soon")).toBeInTheDocument();
+    test("renders correct commons name", async () => {
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/commons/plus", { params: { id: 1 } }).reply(200, {
+            commons: {
+                id: 1,
+                name: "Sample Commons",
+            },
+            totalPlayers: 5,
+            totalCows: 5,
+        });
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminAnnouncementsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        expect(await screen.findByText("Announcements for Sample Commons")).toBeInTheDocument();
     });
 
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we edited the Announcements Index Page so that it will display a heading that tells the user what which commons the announcements are for. The format of the heading is "Announcements for {commons_name}".

## Screenshots 
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
Created a new common called "Test Comm." and clicked on the Announcements button which led to the index page with the correct heading.
![image](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/97550852/a0aa8230-e325-42d5-b4ff-2bec9cbd88b3)
![image](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/97550852/fa1a8cb4-d74a-4fd0-a8a7-86b7379ad69c)

## Future Possibilities
<!--What do you think this project could become? Delete if not needed.-->
- This is the beginning/part of allowing the admin to create/edit/delete announcements for a certain common.

## Validation 
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch or go on my dev link: https://happycows-jasontnguyen-dev.dokku-05.cs.ucsb.edu/
2. As an admin, go to the Admin tab and click List Commons
3. For any of the commons, click the blue Announcements button
4. Make sure it leads you to a page with the correct heading and url.
5. You can also create a new commons from scratch and perform the steps above and test

## Tests
<!--Add any additional tests or required tests-->
- Run the tests in `frontend/src/tests/pages/AdminAnnouncementsPage.test.js` that will confirm whether the page will display the correct commons name

## Linked Issues
<!--Issues related to the PR-->
Closes #31 
