### PR TITLE
Leave Button Implemented (FRONTEND)

### DIFF
--- a/frontend/src/main/components/Commons/CommonsCard.js
+++ b/frontend/src/main/components/Commons/CommonsCard.js
@@ -24,7 +24,7 @@ function isFutureDate(startingDate) {
     }
 }
 
-const CommonsCard = ({ buttonText, buttonLink, commons }) => {
+const CommonsCard = ({ buttonText, buttonLink, commons, leaveButtonLink }) => {
     const testIdPrefix = "commonsCard";
     return (
         <Card.Body style={
@@ -48,8 +48,18 @@ const CommonsCard = ({ buttonText, buttonLink, commons }) => {
                                     } else {
                                         buttonLink(commons.id);
                                     }
-                                    }} >{buttonText}
+                                }}>{buttonText}
                             </Button>
+                            {buttonText === "Visit" &&
+                                <Button
+                                    data-testid={`${testIdPrefix}-button-leave-${commons.id}`}
+                                    size="sm"
+                                    variant="danger"
+                                    onClick={() => leaveButtonLink(commons.id)}
+                                >
+                                    Leave
+                                </Button>
+                            }
                         </Col>
                     }
                 </Row>
@@ -57,8 +67,5 @@ const CommonsCard = ({ buttonText, buttonLink, commons }) => {
         </Card.Body>
     );
 };
-
-
-
 
 export default CommonsCard;

--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -36,7 +36,8 @@ const CommonsList = (props) => {
                 </Card.Subtitle>
                 {
                     props.commonList.map(
-                        (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} />)
+                        (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} 
+                            leaveButtonLink = {props.leaveButtonLink} />)
                     )
                 }
             </React.Fragment> 

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -33,6 +33,20 @@ export default function HomePage({hour=null}) {
     }
   });
 
+  const objectToAxiosParamsLeave = (commonsId) => ({
+    url: "/api/commons/{commonsId}/users/{userId}",
+    method: "DELETE",
+    params: {
+        commonsId
+    }
+});
+
+const leaveMutation = useBackendMutation(
+  ({ commonsId, userId }) => objectToAxiosParamsLeave(commonsId, userId),
+  {},
+  ["/api/currentUser"]
+);
+
   // Stryker disable all : it is acceptable to exclude useBackendMutation calls from mutation testing
   const mutation = useBackendMutation(
     objectToAxiosParams,
@@ -59,6 +73,10 @@ export default function HomePage({hour=null}) {
 
   let navigate = useNavigate();
   const visitButtonClick = (id) => { navigate("/play/" + id) };
+  const leaveButtonClick = (commonsId) => {
+    const userId = currentUser.root.user.id;
+    leaveMutation.mutate({ commonsId, userId });
+}
 
   //create a list of commons that the user hasn't joined for use in the "Join a New Commons" list.
   const commonsNotJoinedList = commonsNotJoined(commons, commonsJoined);
@@ -73,7 +91,9 @@ export default function HomePage({hour=null}) {
       </Card>
         <Container>
           <Row>
-            <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} /></Col>
+            <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick}
+            leaveButtonText={"Leave"} 
+            leaveButtonLink = {leaveButtonClick} /></Col>
             <Col sm><CommonsList commonList={commonsNotJoinedList} title="Join A New Commons" buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
           </Row>
         </Container>

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -33,19 +33,9 @@ export default function HomePage({hour=null}) {
     }
   });
 
-  const objectToAxiosParamsLeave = (commonsId) => ({
-    url: "/api/commons/{commonsId}/users/{userId}",
-    method: "DELETE",
-    params: {
-        commonsId
-    }
-});
 
-const leaveMutation = useBackendMutation(
-  ({ commonsId, userId }) => objectToAxiosParamsLeave(commonsId, userId),
-  {},
-  ["/api/currentUser"]
-);
+
+
 
   // Stryker disable all : it is acceptable to exclude useBackendMutation calls from mutation testing
   const mutation = useBackendMutation(
@@ -73,10 +63,7 @@ const leaveMutation = useBackendMutation(
 
   let navigate = useNavigate();
   const visitButtonClick = (id) => { navigate("/play/" + id) };
-  const leaveButtonClick = (commonsId) => {
-    const userId = currentUser.root.user.id;
-    leaveMutation.mutate({ commonsId, userId });
-}
+  const leaveButtonClick = null;
 
   //create a list of commons that the user hasn't joined for use in the "Join a New Commons" list.
   const commonsNotJoinedList = commonsNotJoined(commons, commonsJoined);
@@ -92,7 +79,6 @@ const leaveMutation = useBackendMutation(
         <Container>
           <Row>
             <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick}
-            leaveButtonText={"Leave"} 
             leaveButtonLink = {leaveButtonClick} /></Col>
             <Col sm><CommonsList commonList={commonsNotJoinedList} title="Join A New Commons" buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
           </Row>

--- a/frontend/src/tests/components/Commons/CommonsCard.test.js
+++ b/frontend/src/tests/components/Commons/CommonsCard.test.js
@@ -155,4 +155,27 @@ describe("CommonsCard tests", () => {
         fireEvent.click(button);
         expect(click).toBeCalledTimes(1);
     });
+
+    test("renders leave button when button text is Visit and clicking it calls leaveButtonLink", async () => {
+        const visitClick = jest.fn();
+        const leaveClick = jest.fn();
+        render(
+            <CommonsCard commons={commonsFixtures.threeCommons[0]} buttonText={"Visit"} buttonLink={visitClick} leaveButtonLink={leaveClick} />
+        );
+
+        const visitButton = screen.getByTestId("commonsCard-button-Visit-5");
+        expect(visitButton).toBeInTheDocument();
+        expect(typeof (visitButton.textContent)).toBe('string');
+        expect(visitButton.textContent).toEqual('Visit');
+        fireEvent.click(visitButton);
+        expect(visitClick).toBeCalledTimes(1);
+
+        const leaveButton = screen.getByTestId("commonsCard-button-leave-5");
+        expect(leaveButton).toBeInTheDocument();
+        expect(typeof (leaveButton.textContent)).toBe('string');
+        expect(leaveButton.textContent).toEqual('Leave');
+        fireEvent.click(leaveButton);
+        expect(leaveClick).toBeCalledTimes(1);
+    });
+
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, the Leave button was implemented on the frontend. 

## Screenshots

<img width="734" alt="Screen Shot 2024-05-22 at 6 40 47 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/124761765/1b6522de-1629-44ef-8f0a-511c8aa45628">


## Feedback Request (Optional)
<!--Anywhere specific you want reviewers to take a look at and give suggestions. Delete if not needed.-->

I know I was supposed to implement the backend first, but I'm a bit confused on how the endpoint works for the backend side. When I eventually implement the backend, would I call the API endpoint using the commonsId/user/userId? It's a bit different from /api/commons/join since I'm not doing /delete or /leave. Would love some clarification.

## Future Possibilities

This is the beginning of the implementation of a button to leave a common when joining it. I ended up doing the frontend first out of simplicity, but I will now begin on the backend to finish up both ends.




## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Assuming you're an admin, create a common.
4. Join the test common.
5. Check if the Leave button is present next to Join.

## Tests

- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #21 
