### PR TITLE
Updated pom.xml so partial pitest runs work

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,15 @@ In order to run the end-to-end tests 'not headless' use the following instead of
 ```
 INTEGRATION=true HEADLESS=false mvn failsafe:integration-test
 ```
+## Partial pitest runs
+
+This repo has support for partial pitest runs
+
+For example, to run pitest on just one class, use:
+```
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.happiercows.controllers.CommonsController
+```
+To run pitest on just one package, use:
+```
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.happiercows.controllers.\*
+```

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
     <description>A Simulation Game of the Tragedy of the Commons.</description>
     <properties>
         <java.version>17</java.version>
+        <targetClasses>edu.ucsb.cs156.*</targetClasses>
+        <targetTests>edu.ucsb.cs156.*</targetTests>
     </properties>
     <dependencies>
         <dependency>
@@ -237,7 +239,7 @@
                     </historyOutputFile>
                     <verbose>true</verbose>
                     <targetClasses>
-                        <param>edu.ucsb.cs156.*</param>
+                        <param>${targetClasses}</param>
                     </targetClasses>
                     <targetTests>
                         <param>edu.ucsb.cs156.*</param>


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we updated the pom.xml so it's possible to run 'mvn pitest:mutationCoverage' on just a single class, or just a single package, instead of the entire backend code base.

## Screenshots

On Controllers Package:
<img width="575" alt="Screen Shot 2024-05-24 at 8 46 00 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/124761765/c5221e6f-472d-475b-a23d-51d7e9022fb1">

On only Commons Controller:
<img width="583" alt="Screen Shot 2024-05-24 at 8 56 58 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/124761765/70f515a6-ac37-4746-855e-787ba8446ed2">

On Api Controller:

<img width="567" alt="Screen Shot 2024-05-24 at 9 07 13 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/124761765/e19c16b0-3d04-4e8c-bcf9-8e060cae1e40">






## Validation 
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the commands from the test section below
3. Verify that the mutations are all accounted for with all tests passing

## Tests
<!--Add any additional tests or required tests-->
- [ ] Backend Commons Controller Pitest coverage (`mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.happiercows.controllers.CommonsController`) pass
- [ ] Backend All Controllers Pitest coverage (`mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.example.controllers.`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Backend API Controller Pitest coverage ('mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.happiercows.controllers.ApiController') pass


## Linked Issues
<!--Issues related to the PR-->

Closes #44 
