### PR TITLE
Improve Homepage UI

### DIFF
--- a/frontend/src/main/components/Commons/CommonsCard.js
+++ b/frontend/src/main/components/Commons/CommonsCard.js
@@ -24,16 +24,16 @@ function isFutureDate(startingDate) {
     }
 }
 
-const CommonsCard = ({ buttonText, buttonLink, commons }) => {
+const CommonsCard = ({ buttonText, buttonLink, commons ,color}) => {
     const testIdPrefix = "commonsCard";
     return (
         <Card.Body style={
             // Stryker disable next-line all : don't mutation test CSS 
-            { fontSize: "20px", borderTop: "1px solid lightgrey" }
+            { fontSize: "20px", borderTop: "1px solid lightgrey",backgroundColor: color ,boxShadow: "0px 4px 8px rgba(0, 0, 0, 0.1)"}
         }>
             <Container>
                 <Row>
-                    <Col sx={4} data-testid={`${testIdPrefix}-id-${commons.id}`}>{commons.id}</Col>
+                    {/* <Col sx={4} data-testid={`${testIdPrefix}-id-${commons.id}`}>{commons.id}</Col> */}
                     <Col sx={4} data-testid={`${testIdPrefix}-name-${commons.id}`}>{commons.name}</Col>
                     {buttonText != null &&
                         <Col sm={4}>

--- a/frontend/src/main/components/Commons/CommonsCard.js
+++ b/frontend/src/main/components/Commons/CommonsCard.js
@@ -33,7 +33,6 @@ const CommonsCard = ({ buttonText, buttonLink, commons ,color}) => {
         }>
             <Container>
                 <Row>
-                    {/* <Col sx={4} data-testid={`${testIdPrefix}-id-${commons.id}`}>{commons.id}</Col> */}
                     <Col sx={4} data-testid={`${testIdPrefix}-name-${commons.id}`}>{commons.name}</Col>
                     {buttonText != null &&
                         <Col sm={4}>

--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -5,7 +5,7 @@ import { Card, Container, Row, Col } from "react-bootstrap";
 const CommonsList = (props) => {
     const defaultMessage = props.title?.includes("Join") ? "join" : "visit";
     // Stryker disable next-line all: don't test CSS params
-    const colors = ["#FFB6C1", "#FFD700", "#ADFF2F", "#87CEFA", "#FF69B4", "#FFA07A", "#20B2AA", "#778899"];
+    const colors = ["#FFB6C1", "#FFD700", "#ADFF2F", "#87CEFA", "#FF69B4", "#FFA07A", "#20B2AA", "#778899","#FFB6C1", "#FFD700", "#ADFF2F", "#87CEFA", "#FF69B4", "#FFA07A", "#20B2AA", "#778899","#FFB6C1", "#FFD700", "#ADFF2F", "#87CEFA", "#FF69B4", "#FFA07A", "#20B2AA", "#778899","#FFB6C1", "#FFD700", "#ADFF2F", "#87CEFA", "#FF69B4", "#FFA07A", "#20B2AA", "#778899"];
     return (
         <Card
             style={
@@ -37,7 +37,7 @@ const CommonsList = (props) => {
                 </Card.Subtitle>
                 {
                     props.commonList.map(
-                        (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} color = {colors[c.id % colors.length]}/>)
+                        (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} color = {colors[c.id]}/>)
                     )
                 }
             </React.Fragment> 

--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -4,12 +4,12 @@ import { Card, Container, Row, Col } from "react-bootstrap";
 
 const CommonsList = (props) => {
     const defaultMessage = props.title?.includes("Join") ? "join" : "visit";
-
+    const colors = ["#FFB6C1", "#FFD700", "#ADFF2F", "#87CEFA", "#FF69B4", "#FFA07A", "#20B2AA", "#778899"];
     return (
         <Card
             style={
                 // Stryker disable next-line all: don't test CSS params
-                { opacity: ".9" }
+                { opacity: ".9",boxShadow: "0px 4px 8px rgba(0, 0, 0, 0.1)"}
             }
             className="my-3 border-0"
         >
@@ -28,7 +28,7 @@ const CommonsList = (props) => {
                 <Card.Subtitle>
                     <Container>
                         <Row>
-                            <Col data-testid="commonsList-subtitle-id" sx={4}>ID#</Col>
+                            {/* <Col data-testid="commonsList-subtitle-id" sx={4}>ID#</Col> */}
                             <Col data-testid="commonsList-subtitle-name" sx={4}>Common's Name</Col>
                             <Col sm={4}></Col>
                         </Row>
@@ -36,7 +36,7 @@ const CommonsList = (props) => {
                 </Card.Subtitle>
                 {
                     props.commonList.map(
-                        (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} />)
+                        (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} color = {colors[c.id % colors.length]}/>)
                     )
                 }
             </React.Fragment> 

--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -4,6 +4,7 @@ import { Card, Container, Row, Col } from "react-bootstrap";
 
 const CommonsList = (props) => {
     const defaultMessage = props.title?.includes("Join") ? "join" : "visit";
+    // Stryker disable next-line all: don't test CSS params
     const colors = ["#FFB6C1", "#FFD700", "#ADFF2F", "#87CEFA", "#FF69B4", "#FFA07A", "#20B2AA", "#778899"];
     return (
         <Card

--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -5,7 +5,18 @@ import { Card, Container, Row, Col } from "react-bootstrap";
 const CommonsList = (props) => {
     const defaultMessage = props.title?.includes("Join") ? "join" : "visit";
     // Stryker disable next-line all: don't test CSS params
-    const colors = ["#FFB6C1", "#FFD700", "#ADFF2F", "#87CEFA", "#FF69B4", "#FFA07A", "#20B2AA", "#778899","#FFB6C1", "#FFD700", "#ADFF2F", "#87CEFA", "#FF69B4", "#FFA07A", "#20B2AA", "#778899","#FFB6C1", "#FFD700", "#ADFF2F", "#87CEFA", "#FF69B4", "#FFA07A", "#20B2AA", "#778899","#FFB6C1", "#FFD700", "#ADFF2F", "#87CEFA", "#FF69B4", "#FFA07A", "#20B2AA", "#778899"];
+    function getRandomColor() {
+        // Stryker disable next-line all: don't test CSS params
+        const red = Math.floor(Math.random() * 256);    
+        // Stryker disable next-line all: don't test CSS params
+        const green = Math.floor(Math.random() * 256);
+        // Stryker disable next-line all: don't test CSS params 
+        const blue = Math.floor(Math.random() * 256);
+        // Stryker disable next-line all: don't test CSS params
+        return `rgba(${red}, ${green}, ${blue},0.3)`; 
+    }
+    
+
     return (
         <Card
             style={
@@ -29,7 +40,6 @@ const CommonsList = (props) => {
                 <Card.Subtitle>
                     <Container>
                         <Row>
-                            {/* <Col data-testid="commonsList-subtitle-id" sx={4}>ID#</Col> */}
                             <Col data-testid="commonsList-subtitle-name" sx={4}>Common's Name</Col>
                             <Col sm={4}></Col>
                         </Row>
@@ -37,7 +47,8 @@ const CommonsList = (props) => {
                 </Card.Subtitle>
                 {
                     props.commonList.map(
-                        (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} color = {colors[c.id]}/>)
+                        
+                        (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} color={getRandomColor()}/>)
                     )
                 }
             </React.Fragment> 

--- a/frontend/src/tests/components/Commons/CommonsCard.test.js
+++ b/frontend/src/tests/components/Commons/CommonsCard.test.js
@@ -24,10 +24,10 @@ describe("CommonsCard tests", () => {
         expect(typeof (name.textContent)).toBe('string');
         expect(name.textContent).toEqual('Seths Common');
 
-        const id = screen.getByTestId("commonsCard-id-5");
-        expect(id).toBeInTheDocument();
-        expect(typeof (id.textContent)).toBe('string');
-        expect(id.textContent).toEqual('5');
+        // const id = screen.getByTestId("commonsCard-id-5");
+        // expect(id).toBeInTheDocument();
+        // expect(typeof (id.textContent)).toBe('string');
+        // expect(id.textContent).toEqual('5');
     });
 
     test("renders no button when button text is null", () => {
@@ -42,10 +42,10 @@ describe("CommonsCard tests", () => {
         expect(typeof (name.textContent)).toBe('string');
         expect(name.textContent).toEqual('Seths Common');
 
-        const id = screen.getByTestId("commonsCard-id-5");
-        expect(id).toBeInTheDocument();
-        expect(typeof (id.textContent)).toBe('string');
-        expect(id.textContent).toEqual('5');
+        // const id = screen.getByTestId("commonsCard-id-5");
+        // expect(id).toBeInTheDocument();
+        // expect(typeof (id.textContent)).toBe('string');
+        // expect(id.textContent).toEqual('5');
     });
 
     test("cannot join commons with future start date - future year", async () => {

--- a/frontend/src/tests/components/Commons/CommonsCard.test.js
+++ b/frontend/src/tests/components/Commons/CommonsCard.test.js
@@ -23,11 +23,6 @@ describe("CommonsCard tests", () => {
         expect(name).toBeInTheDocument();
         expect(typeof (name.textContent)).toBe('string');
         expect(name.textContent).toEqual('Seths Common');
-
-        // const id = screen.getByTestId("commonsCard-id-5");
-        // expect(id).toBeInTheDocument();
-        // expect(typeof (id.textContent)).toBe('string');
-        // expect(id.textContent).toEqual('5');
     });
 
     test("renders no button when button text is null", () => {
@@ -42,10 +37,6 @@ describe("CommonsCard tests", () => {
         expect(typeof (name.textContent)).toBe('string');
         expect(name.textContent).toEqual('Seths Common');
 
-        // const id = screen.getByTestId("commonsCard-id-5");
-        // expect(id).toBeInTheDocument();
-        // expect(typeof (id.textContent)).toBe('string');
-        // expect(id.textContent).toEqual('5');
     });
 
     test("cannot join commons with future start date - future year", async () => {

--- a/frontend/src/tests/components/Commons/CommonsList.test.js
+++ b/frontend/src/tests/components/Commons/CommonsList.test.js
@@ -18,10 +18,10 @@ describe("CommonsList tests", () => {
         expect(typeof(subtitle_name.textContent)).toBe('string');
         expect(subtitle_name.textContent).toEqual("Common's Name");
 
-        const subtitle_id = screen.getByTestId("commonsList-subtitle-id");
-        expect(subtitle_id).toBeInTheDocument();
-        expect(typeof(subtitle_id.textContent)).toBe('string');
-        expect(subtitle_id.textContent).toEqual('ID#');
+        // const subtitle_id = screen.getByTestId("commonsList-subtitle-id");
+        // expect(subtitle_id).toBeInTheDocument();
+        // expect(typeof(subtitle_id.textContent)).toBe('string');
+        // expect(subtitle_id.textContent).toEqual('ID#');
 
         const buttons = screen.getAllByTestId(/commonsCard-button/);
         buttons.forEach((b) => {
@@ -39,14 +39,14 @@ describe("CommonsList tests", () => {
             i++;
         })
 
-        i = 0;
-        const ids = screen.getAllByTestId(/commonsCard-id/);
-        ids.forEach((id) => {
-            expect(id).toBeInTheDocument();
-            expect(typeof(id.textContent)).toBe('string');
-            expect(id.textContent).toEqual(commonsFixtures.threeCommons[i].id.toString());
-            i++;
-        })
+        // i = 0;
+        // const ids = screen.getAllByTestId(/commonsCard-id/);
+        // ids.forEach((id) => {
+        //     expect(id).toBeInTheDocument();
+        //     expect(typeof(id.textContent)).toBe('string');
+        //     expect(id.textContent).toEqual(commonsFixtures.threeCommons[i].id.toString());
+        //     i++;
+        // })
     });
 
     test("renders no button when button text is null", () => {
@@ -64,10 +64,10 @@ describe("CommonsList tests", () => {
         expect(typeof(subtitle_name.textContent)).toBe('string');
         expect(subtitle_name.textContent).toEqual("Common's Name");
 
-        const subtitle_id = screen.getByTestId("commonsList-subtitle-id");
-        expect(subtitle_id).toBeInTheDocument();
-        expect(typeof(subtitle_id.textContent)).toBe('string');
-        expect(subtitle_id.textContent).toEqual('ID#');
+        // const subtitle_id = screen.getByTestId("commonsList-subtitle-id");
+        // expect(subtitle_id).toBeInTheDocument();
+        // expect(typeof(subtitle_id.textContent)).toBe('string');
+        // expect(subtitle_id.textContent).toEqual('ID#');
 
         expect(() => screen.getAllByTestId(/commonsCard-button/)).toThrow('Unable to find an element');
 
@@ -80,14 +80,14 @@ describe("CommonsList tests", () => {
             i++;
         })
 
-        i = 0;
-        const ids = screen.getAllByTestId(/commonsCard-id/);
-        ids.forEach((id) => {
-            expect(id).toBeInTheDocument();
-            expect(typeof(id.textContent)).toBe('string');
-            expect(id.textContent).toEqual(commonsFixtures.threeCommons[i].id.toString());
-            i++;
-        })
+        // i = 0;
+        // const ids = screen.getAllByTestId(/commonsCard-id/);
+        // ids.forEach((id) => {
+        //     expect(id).toBeInTheDocument();
+        //     expect(typeof(id.textContent)).toBe('string');
+        //     expect(id.textContent).toEqual(commonsFixtures.threeCommons[i].id.toString());
+        //     i++;
+        // })
     });
 
     test("renders default join UI when there are no commons", () => {

--- a/frontend/src/tests/components/Commons/CommonsList.test.js
+++ b/frontend/src/tests/components/Commons/CommonsList.test.js
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import '@testing-library/jest-dom';
 import CommonsList from "main/components/Commons/CommonsList"; 
 import commonsFixtures from "fixtures/commonsFixtures"; 
 
@@ -17,12 +18,6 @@ describe("CommonsList tests", () => {
         expect(subtitle_name).toBeInTheDocument();
         expect(typeof(subtitle_name.textContent)).toBe('string');
         expect(subtitle_name.textContent).toEqual("Common's Name");
-
-        // const subtitle_id = screen.getByTestId("commonsList-subtitle-id");
-        // expect(subtitle_id).toBeInTheDocument();
-        // expect(typeof(subtitle_id.textContent)).toBe('string');
-        // expect(subtitle_id.textContent).toEqual('ID#');
-
         const buttons = screen.getAllByTestId(/commonsCard-button/);
         buttons.forEach((b) => {
             expect(b).toBeInTheDocument();
@@ -38,15 +33,6 @@ describe("CommonsList tests", () => {
             expect(n.textContent).toEqual(commonsFixtures.threeCommons[i].name);
             i++;
         })
-
-        // i = 0;
-        // const ids = screen.getAllByTestId(/commonsCard-id/);
-        // ids.forEach((id) => {
-        //     expect(id).toBeInTheDocument();
-        //     expect(typeof(id.textContent)).toBe('string');
-        //     expect(id.textContent).toEqual(commonsFixtures.threeCommons[i].id.toString());
-        //     i++;
-        // })
     });
 
     test("renders no button when button text is null", () => {
@@ -64,11 +50,6 @@ describe("CommonsList tests", () => {
         expect(typeof(subtitle_name.textContent)).toBe('string');
         expect(subtitle_name.textContent).toEqual("Common's Name");
 
-        // const subtitle_id = screen.getByTestId("commonsList-subtitle-id");
-        // expect(subtitle_id).toBeInTheDocument();
-        // expect(typeof(subtitle_id.textContent)).toBe('string');
-        // expect(subtitle_id.textContent).toEqual('ID#');
-
         expect(() => screen.getAllByTestId(/commonsCard-button/)).toThrow('Unable to find an element');
 
         let i = 0;
@@ -79,15 +60,6 @@ describe("CommonsList tests", () => {
             expect(n.textContent).toEqual(commonsFixtures.threeCommons[i].name);
             i++;
         })
-
-        // i = 0;
-        // const ids = screen.getAllByTestId(/commonsCard-id/);
-        // ids.forEach((id) => {
-        //     expect(id).toBeInTheDocument();
-        //     expect(typeof(id.textContent)).toBe('string');
-        //     expect(id.textContent).toEqual(commonsFixtures.threeCommons[i].id.toString());
-        //     i++;
-        // })
     });
 
     test("renders default join UI when there are no commons", () => {
@@ -127,4 +99,5 @@ describe("CommonsList tests", () => {
 
         expect(() => screen.getByTestId("commonsList-subtitle-name")).toThrow('Unable to find an element');
     });
+    
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I add a shadow to the containers, remove the IDs from the home page, and change the color of each common card so that users can easily differentiate cards, even cards with the same name

## Screenshots (Optional)
<img width="1341" alt="Screenshot 2024-05-24 at 10 30 14 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/97069739/4a4214cb-55ff-41e3-955a-19b05c2fdf55">


## Future Possibilities (Optional)
Right now the home page only has a simple UI, I think it would be better if it had animation to make the page more interactive

## Validation (Optional)
1. Go to https://happycows-congruidu-dev.dokku-05.cs.ucsb.edu
2. Run the project.
3. Go to the Home page.
4. See if the ID is still shown, and cards have different background colors.

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues

Closes https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/issues/6
