### PR TITLE
Fixed disallowing users to navigate to unjoined commons

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,16 @@ In order to run the end-to-end tests 'not headless' use the following instead of
 ```
 INTEGRATION=true HEADLESS=false mvn failsafe:integration-test
 ```
+
+## Partial pitest runs
+
+This repo has support for partial pitest runs
+
+For example, to run pitest on just one class, use:
+```
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.happiercows.controllers.CommonsController
+```
+To run pitest on just one package, use:
+```
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.happiercows.controllers.\*
+```

--- a/README.md
+++ b/README.md
@@ -123,16 +123,3 @@ In order to run the end-to-end tests 'not headless' use the following instead of
 ```
 INTEGRATION=true HEADLESS=false mvn failsafe:integration-test
 ```
-
-## Partial pitest runs
-
-This repo has support for partial pitest runs
-
-For example, to run pitest on just one class, use:
-```
-mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.happiercows.controllers.CommonsController
-```
-To run pitest on just one package, use:
-```
-mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.happiercows.controllers.\*
-```

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -150,6 +150,8 @@ export default function PlayPage() {
         fontSize: "30px",
     };
 
+    const isUserInCommon = currentUser?.root?.user?.commons?.some(common => common.id === parseInt(commonsId));
+
     return (
         <div
             style={{
@@ -160,7 +162,11 @@ export default function PlayPage() {
         >
             <BasicLayout>
                 <Container>
-                    {!!currentUser && <CommonsPlay currentUser={currentUser} />}
+                {isUserInCommon && !!currentUser && <CommonsPlay currentUser={currentUser} />}
+                    {!isUserInCommon && currentUser && <h1 style={{ color: 'red', backgroundColor: 'black', padding: '50px', 
+                    textAlign: 'center' }}>
+                        Access Denied.
+                    </h1> }   
                     {!!commonsPlus && (
                         <CommonsOverview
                             commonsPlus={commonsPlus}

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -150,6 +150,7 @@ export default function PlayPage() {
         fontSize: "30px",
     };
 
+    // Stryker disable next-line OptionalChaining
     const isUserInCommon = currentUser?.root?.user?.commons?.some(common => common.id === parseInt(commonsId));
 
     return (

--- a/frontend/src/tests/components/Commons/CommonsOverview.test.js
+++ b/frontend/src/tests/components/Commons/CommonsOverview.test.js
@@ -39,7 +39,7 @@ describe("CommonsOverview tests", () => {
     });
 
     test("Redirects to the LeaderboardPage for an admin when you click visit", async () => {
-        apiCurrentUserFixtures.adminUser.user.commons = commonsFixtures.oneCommons[0];
+        apiCurrentUserFixtures.adminUser.user.commons[0] = commonsFixtures.oneCommons;
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
         axiosMock.onGet("/api/commons/plus", {params: {id:1}}).reply(200, commonsPlusFixtures.oneCommonsPlus[0]);
         axiosMock.onGet("/api/leaderboard/all").reply(200, leaderboardFixtures.threeUserCommonsLB);
@@ -68,7 +68,7 @@ describe("CommonsOverview tests", () => {
             ...commonsPlusFixtures.oneCommonsPlus,
             commons : ourCommons
         }
-        apiCurrentUserFixtures.userOnly.user.commonsPlus = commonsPlusFixtures.oneCommonsPlus[0];
+        apiCurrentUserFixtures.userOnly.user.commonsPlus = ourCommons;
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/commons/plus", {params: {id:1}}).reply(200, ourCommonsPlus);
         axiosMock.onGet("/api/leaderboard/all").reply(200, leaderboardFixtures.threeUserCommonsLB);

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -347,50 +347,30 @@ describe("PlayPage tests", () => {
     })
 
 
-    test("Shows 'Access Denied' message if user is not in the commons", async () => {
-        const userCommons = {
-            commonsId: 2, // Different commons ID to simulate user not in the current commons
-            id: 1,
-            totalWealth: 0,
-            userId: 1,
-        };
+    test("user has not joined the commons (single commons joined)", async () => {
+
         axiosMock.reset();
         axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, {
-            ...apiCurrentUserFixtures.userOnly,
-            root: {
-                ...apiCurrentUserFixtures.userOnly.root,
-                user: {
-                    ...apiCurrentUserFixtures.userOnly.root.user,
-                    commons: [userCommons]
-                }
-            }
-        });
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-        axiosMock.onGet("/api/usercommons/forcurrentuser", { params: { commonsId: 1 } }).reply(404); // Simulate not found
-        axiosMock.onGet("/api/commons", { params: { id: 1 } }).reply(200, {
-            id: 1,
-            name: "Sample Commons"
-        });
-        axiosMock.onGet("/api/commons/all").reply(200, [
-            {
-                id: 1,
-                name: "Sample Commons"
-            }
-        ]);
-        axiosMock.onGet("/api/commons/plus", { params: { id: 1 } }).reply(200, {
-            commons: {
-                id: 1,
-                name: "Sample Commons",
-                showChat: true
-            },
-            totalPlayers: 5,
-            totalCows: 5 
-        });
-        axiosMock.onGet("/api/profits/all/commonsid").reply(200, []);
-        axiosMock.onPut("/api/usercommons/sell").reply(200, userCommons);
-        axiosMock.onPut("/api/usercommons/buy").reply(200, userCommons);
-        
+
+        axiosMock.onGet("/api/currentUser").reply(200, {
+
+        user: {
+            id : 1,
+            fullName : "Nom Guerre",
+            givenName : "Nom",
+            familyName : "Guerre",
+            emailVerified : true,
+            admin : false,
+            commons : [
+                {
+                    id : 2,
+                    name : "TestCommons",
+                }
+            ]
+
+        }});
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -398,19 +378,15 @@ describe("PlayPage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
-    
 
         await waitFor(() => {
-            const accessDeniedMessage = screen.getByText("Access Denied.");
-            expect(accessDeniedMessage).toBeInTheDocument();
+            expect(screen.getByText("Access Denied.")).toBeInTheDocument();    
         });
-    
-        const accessDeniedMessage = screen.getByText("Access Denied.");
-        expect(accessDeniedMessage).toHaveStyle('color: red');
-        expect(accessDeniedMessage).toHaveStyle('background-color: black');
-        expect(accessDeniedMessage).toHaveStyle('padding: 50px');
-        expect(accessDeniedMessage).toHaveStyle('text-align: center');
-    });
+
+        expect(screen.getByText("Access Denied.")).toBeInTheDocument();   
+        expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();    
+
+    })
     
 
 });

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -379,18 +379,15 @@ describe("PlayPage tests", () => {
             </QueryClientProvider>
         );
 
-        await waitFor(() => {
-            const accessDeniedElement = screen.getByText("Access Denied.");
-            expect(accessDeniedElement).toBeInTheDocument();
+        const accessDeniedElement = await screen.findByText("Access Denied.");
+        expect(accessDeniedElement).toBeInTheDocument();
     
-            const styles = window.getComputedStyle(accessDeniedElement);
-            expect(styles.backgroundColor).toBe("black");
-            expect(styles.color).toBe("red");
-            expect(styles.textAlign).toBe("center");
-            expect(styles.padding).toBe("50px");
-        });
+        const styles = window.getComputedStyle(accessDeniedElement);
+        expect(styles.backgroundColor).toBe("black");
+        expect(styles.color).toBe("red");
+        expect(styles.textAlign).toBe("center");
+        expect(styles.padding).toBe("50px");
     
-        expect(screen.getByText("Access Denied.")).toBeInTheDocument();
         expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
     
 
@@ -416,11 +413,11 @@ test("user has not joined the commons (multiple commons)", async () => {
         commons : [
             {
                 id : 2,
-                name : "TestCommons",
+                name : "Not this one",
             },
             {
                 id : 3,
-                name : "OtherTestCommons",
+                name : "Don't exist!",
             }
         ]
 
@@ -434,19 +431,16 @@ test("user has not joined the commons (multiple commons)", async () => {
         </QueryClientProvider>
     );
 
-    await waitFor(() => {
-        const accessDeniedElement = screen.getByText("Access Denied.");
-        expect(accessDeniedElement).toBeInTheDocument();
+    const accessDeniedElement = await screen.findByText("Access Denied.");
+    expect(accessDeniedElement).toBeInTheDocument();
 
-        const styles = window.getComputedStyle(accessDeniedElement);
-        expect(styles.backgroundColor).toBe("black");
-        expect(styles.color).toBe("red");
-        expect(styles.textAlign).toBe("center");
-        expect(styles.padding).toBe("50px");
-    });
+    const styles = window.getComputedStyle(accessDeniedElement);
+    expect(styles.backgroundColor).toBe("black");
+    expect(styles.color).toBe("red");
+    expect(styles.textAlign).toBe("center");
+    expect(styles.padding).toBe("50px");
 
-    expect(screen.getByText("Access Denied.")).toBeInTheDocument();
-    expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();  
+    expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
 
 })
 
@@ -467,8 +461,8 @@ test("user has joined the commons (single common)", async () => {
         admin : false,
         commons : [
             {
-                id : 4,
-                name : "Test Commons",
+                id : 1,
+                name : "da test zone",
             }
         ]
 
@@ -505,7 +499,7 @@ test("user has joined the commons (multiple commons)", async () => {
     axiosMock.onGet("/api/currentUser").reply(200, {
 
     user: {
-        id : 12,
+        id : 1,
         fullName : "steven le",
         givenName : "steven",
         familyName : "Team 5",
@@ -513,11 +507,11 @@ test("user has joined the commons (multiple commons)", async () => {
         admin : false,
         commons : [
             {
-                id : 2,
+                id : 1,
                 name : "Interesting"
             },
             {
-                id : 5,
+                id : 3,
                 name : "Awesome Common!"
             }
         ]

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -380,14 +380,169 @@ describe("PlayPage tests", () => {
         );
 
         await waitFor(() => {
-            expect(screen.getByText("Access Denied.")).toBeInTheDocument();    
+            const accessDeniedElement = screen.getByText("Access Denied.");
+            expect(accessDeniedElement).toBeInTheDocument();
+    
+            const styles = window.getComputedStyle(accessDeniedElement);
+            expect(styles.backgroundColor).toBe("black");
+            expect(styles.color).toBe("red");
+            expect(styles.textAlign).toBe("center");
+            expect(styles.padding).toBe("50px");
         });
-
-        expect(screen.getByText("Access Denied.")).toBeInTheDocument();   
-        expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();    
-
-    })
+    
+        expect(screen.getByText("Access Denied.")).toBeInTheDocument();
+        expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
     
 
 });
 
+
+
+test("user has not joined the commons (multiple commons)", async () => {
+
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+    axiosMock.onGet("/api/currentUser").reply(200, {
+
+    user: {
+        id : 1,
+        fullName : "Steven",
+        givenName : "steven",
+        familyName : "Le",
+        emailVerified : true,
+        admin : false,
+        commons : [
+            {
+                id : 2,
+                name : "TestCommons",
+            },
+            {
+                id : 3,
+                name : "OtherTestCommons",
+            }
+        ]
+
+    }});
+
+    render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+                <PlayPage />
+            </MemoryRouter>
+        </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+        const accessDeniedElement = screen.getByText("Access Denied.");
+        expect(accessDeniedElement).toBeInTheDocument();
+
+        const styles = window.getComputedStyle(accessDeniedElement);
+        expect(styles.backgroundColor).toBe("black");
+        expect(styles.color).toBe("red");
+        expect(styles.textAlign).toBe("center");
+        expect(styles.padding).toBe("50px");
+    });
+
+    expect(screen.getByText("Access Denied.")).toBeInTheDocument();
+    expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();  
+
+})
+
+test("user has joined the commons (single common)", async () => {
+
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+    axiosMock.onGet("/api/currentUser").reply(200, {
+
+    user: {
+        id : 1,
+        fullName : "Test",
+        givenName : "Test",
+        familyName : "Testing",
+        emailVerified : true,
+        admin : false,
+        commons : [
+            {
+                id : 4,
+                name : "Test Commons",
+            }
+        ]
+
+    }});
+
+    render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+                <PlayPage />
+            </MemoryRouter>
+        </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+        expect(screen.getByTestId("commons-card")).toBeInTheDocument();
+
+    });
+
+    await waitFor(() => {
+        expect(screen.getByText("Announcements")).toBeInTheDocument();
+    });        
+
+    expect(screen.getByTestId("commons-card")).toBeInTheDocument();
+    expect(screen.queryByText("Access Denied.")).not.toBeInTheDocument();
+
+})
+
+test("user has joined the commons (multiple commons)", async () => {
+
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+    axiosMock.onGet("/api/currentUser").reply(200, {
+
+    user: {
+        id : 12,
+        fullName : "steven le",
+        givenName : "steven",
+        familyName : "Team 5",
+        emailVerified : true,
+        admin : false,
+        commons : [
+            {
+                id : 2,
+                name : "Interesting"
+            },
+            {
+                id : 5,
+                name : "Awesome Common!"
+            }
+        ]
+
+    }});
+
+    render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+                <PlayPage />
+            </MemoryRouter>
+        </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+        expect(screen.getByTestId("commons-card")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+        expect(screen.getByText("Announcements")).toBeInTheDocument();
+    });        
+
+    expect(screen.getByTestId("commons-card")).toBeInTheDocument();
+    expect(screen.queryByText("Access Denied.")).not.toBeInTheDocument();
+
+})
+
+});

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -347,7 +347,7 @@ describe("PlayPage tests", () => {
     })
 
 
-    test("user has not joined the commons (single commons joined)", async () => {
+    test("disallow user from navigating to unjoined common", async () => {
 
         axiosMock.reset();
         axiosMock.resetHistory();
@@ -357,15 +357,15 @@ describe("PlayPage tests", () => {
 
         user: {
             id : 1,
-            fullName : "Nom Guerre",
-            givenName : "Nom",
-            familyName : "Guerre",
+            fullName : "Steven",
+            givenName : "steven",
+            familyName : "Le",
             emailVerified : true,
             admin : false,
             commons : [
                 {
-                    id : 2,
-                    name : "TestCommons",
+                    id : 3,
+                    name : "Disallowed Commons",
                 }
             ]
 


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we made changes to PlayPage.js to inform users that trying to navigate to a common they are not apart of, that Access is Denied.
We also made changes to PlayPage.test.js as well as CommonsOverview.test.js to maintain compatibility with the PlayPage.js.

## Screenshots (Optional)

<img width="1057" alt="Screen Shot 2024-05-25 at 4 43 54 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/124761765/b88064ed-dac0-4a88-9233-9ba96b731143">

## Feedback Request (Optional)
The error messages that indicate userCommons with commonId and userId are still popping up, cluttering up the far right side. If anybody has a way to suppress those with the condition that the user is not apart of the commons, that would be highly needed. Thanks in advance.

## Future Possibilities (Optional)

We could definitely just try redirecting them to a completely different page that says Access Denied instead of showing the Announcements section and Leaderboard button.


## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Visit https://happycows-nevetsle-dev.dokku-05.cs.ucsb.edu/
2. As an Admin, create a commons and join the first one. Then create a second one, one that you're not in. 
3. enter "/play/#" after the URL (i.e. https://happycows-nevetsle-dev.dokku-05.cs.ucsb.edu), # being the ID of a common you have not joined.
4. The Access Denied message should pop up

## Tests
<!--Add any additional tests or required tests-->
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #9 
