### PR TITLE
Feature: Added Create Announcement Button (Placeholder Page)

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,6 +20,7 @@ import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
 import AdminViewPlayPage from "main/pages/AdminViewPlayPage";
 import AdminAnnouncementsPage from "main/pages/AdminAnnouncementsPage";
+import AdminCreateAnnouncementsPage from "main/pages/AdminCreateAnnouncementsPage";
 
 function App() {
     const { data: currentUser } = useCurrentUser();
@@ -52,6 +53,10 @@ function App() {
             <Route
                 path="/admin/announcements/:commonsId"
                 element={<AdminAnnouncementsPage />}
+            />
+            <Route
+                path="/admin/announcements/:commonsId/create"
+                element={<AdminCreateAnnouncementsPage />}
             />
         </>
     ) : null;

--- a/frontend/src/main/pages/AdminAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminAnnouncementsPage.js
@@ -5,6 +5,7 @@ import { useBackend} from "main/utils/useBackend";
 import { useParams } from "react-router-dom";
 import AnnouncementTable from "main/components/Announcement/AnnouncementTable";
 import { useCurrentUser } from "main/utils/currentUser";
+import { Button } from "react-bootstrap";
 
 export default function AdminAnnouncementsPage() {
     let { commonsId } = useParams();
@@ -42,6 +43,13 @@ export default function AdminAnnouncementsPage() {
         <BasicLayout>
             <div className="pt-2">
                 <h1>Announcements for {commonsName}</h1>
+                <Button
+                    variant="primary"
+                    href={`/admin/announcements/${commonsId}/create`}
+                    style={{ float: "right" }}
+                >
+                    Create Announcement 
+                </Button>
                 <AnnouncementTable announcements={announcements} currentUser={currentUser}/>
             </div>
         </BasicLayout>

--- a/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
@@ -1,0 +1,12 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function AdminCreateAnnouncementsPage() {
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Feature Coming Soon</h1>
+            </div>
+        </BasicLayout>
+    )
+}

--- a/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import AdminCreateAnnouncementsPage from "main/pages/AdminCreateAnnouncementsPage";
+
+describe("AdminCreateAnnouncements tests", () => {
+    const queryClient = new QueryClient();
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(()=>{
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    });
+
+    test("renders correctly without crashing", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminCreateAnnouncementsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText("Feature Coming Soon")).toBeInTheDocument();
+    });
+
+});


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I added a create announcement button on the announcements index page that will lead you to a placeholder page saying the feature is coming soon (implemented in different issue)

## Merge Info
- This PR requires PR #48 first since it requires corrected backend changes in that PR request. I rebased this branch off main first.

## Screenshots
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
<img width="1324" alt="Screenshot 2024-05-25 at 2 03 37 AM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/97550852/01b42cad-eb98-4bc3-9746-43381463084b">
<img width="1331" alt="Screenshot 2024-05-25 at 2 03 52 AM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/97550852/7acda716-ca7f-4a60-917e-0080554ab35c">


## Future Possibilities 
<!--What do you think this project could become? Delete if not needed.-->
- This is the beginning/part of allowing the user to actually create an announcement through the fronted and not through swagger.

## Validation 
<!--Steps that someone else could take to make sure everything is working-->
1. Rebuild my dokku dev app by doing `dokku git:sync happycows-jasontnguyen-dev https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5.git JN-CreateButton` then `dokku ps:rebuild happycows-jasontnguyen-dev`
2. Use my dokku link: https://happycows-jasontnguyen-dev.dokku-05.cs.ucsb.edu
3. Create a new commons and go to List Commons in the admin tab
4. Click the Announcements button and it leads you to the index page
5. Check if the url matches the commons id in the search bar and that the create announcements button leads to the placeholder page

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #49 
