### PR TITLE
Feature: Added Edit Page Placeholder

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -59,6 +59,7 @@ function App() {
             <Route
                 path="/announcements/edit/:announcementId"
                 element={<AdminEditAnnouncementsPage />}
+            />
             <Route
                 path="/admin/announcements/:commonsId/create"
                 element={<AdminCreateAnnouncementsPage />}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,6 +21,8 @@ import NotFoundPage from "main/pages/NotFoundPage";
 import AdminViewPlayPage from "main/pages/AdminViewPlayPage";
 import AdminAnnouncementsPage from "main/pages/AdminAnnouncementsPage";
 
+import AdminEditAnnouncementsPage from "main/pages/AdminEditAnnouncementsPage";
+
 function App() {
     const { data: currentUser } = useCurrentUser();
 
@@ -52,6 +54,14 @@ function App() {
             <Route
                 path="/admin/announcements/:commonsId"
                 element={<AdminAnnouncementsPage />}
+            />
+
+
+
+
+            <Route
+                path="/announcements/edit/:announcementId"
+                element={<AdminEditAnnouncementsPage />}
             />
         </>
     ) : null;

--- a/frontend/src/main/pages/AdminEditAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminEditAnnouncementsPage.js
@@ -1,0 +1,12 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function AdminEditAnnouncementsPage() {
+    return (
+        <BasicLayout>
+            <div className="pt-2">
+                <h1>Feature Coming Soon</h1>
+            </div>
+        </BasicLayout>
+    )
+}

--- a/frontend/src/main/utils/currentUser.js
+++ b/frontend/src/main/utils/currentUser.js
@@ -35,9 +35,14 @@ export function useLogout() {
 }
 
 export function hasRole(currentUser, role) {
-  return currentUser
-    && currentUser.loggedIn
-    && currentUser.root
-    && currentUser.root.rolesList
-    && currentUser.root.rolesList.includes(role)
+  if (currentUser == null) return false;
+
+  if ("data" in currentUser &&
+    "root" in currentUser.data &&
+    currentUser.data.root != null &&
+    "rolesList" in currentUser.data.root) {
+    return currentUser.data.root.rolesList.includes(role);
+  }
+
+  return currentUser.root?.rolesList?.includes(role);
 }

--- a/frontend/src/tests/pages/AdminEditAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminEditAnnouncementsPage.test.js
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import AdminEditAnnouncementsPage from "main/pages/AdminEditAnnouncementsPage";
+
+describe("AdminCreateAnnouncements tests", () => {
+    const queryClient = new QueryClient();
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    beforeEach(()=>{
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    });
+
+    test("renders correctly without crashing", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminEditAnnouncementsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText("Feature Coming Soon")).toBeInTheDocument();
+    });
+
+});

--- a/frontend/src/tests/utils/currentUser.test.js
+++ b/frontend/src/tests/utils/currentUser.test.js
@@ -164,5 +164,48 @@ describe("utils/currentUser tests", () => {
             expect(hasRole({ loggedIn: true, root: { rolesList: ["ROLE_USER"] } }, "ROLE_ADMIN")).toBeFalsy();
             expect(hasRole({ loggedIn: true, root: { rolesList: ["ROLE_USER", "ROLE_ADMIN"] } }, "ROLE_ADMIN")).toBeTruthy();
         });
+        test('hasRole returns false when currentUser is null', () => {
+            expect(hasRole(null, "ROLE_ADMIN")).toBeFalsy();
+        });
+    
+        test('hasRole returns false when currentUser is an empty object', () => {
+            expect(hasRole({}, "ROLE_ADMIN")).toBeFalsy();
+        });
+    
+        test('hasRole returns false when currentUser loggedIn is null', () => {
+            expect(hasRole({ loggedIn: null }, "ROLE_ADMIN")).toBeFalsy();
+        });
+    
+        test('hasRole returns false when currentUser loggedIn is true but root is null', () => {
+            expect(hasRole({ loggedIn: true, root: null }, "ROLE_ADMIN")).toBeFalsy();
+        });
+    
+        test('hasRole returns false when currentUser loggedIn is true but root is an empty object', () => {
+            expect(hasRole({ loggedIn: true, root: {} }, "ROLE_ADMIN")).toBeFalsy();
+        });
+    
+        test('hasRole returns false when currentUser loggedIn is true but rolesList is null', () => {
+            expect(hasRole({ loggedIn: true, root: { rolesList: null } }, "ROLE_ADMIN")).toBeFalsy();
+        });
+    
+        test('hasRole returns false when currentUser loggedIn is true but rolesList is empty', () => {
+            expect(hasRole({ loggedIn: true, root: { rolesList: [] } }, "ROLE_ADMIN")).toBeFalsy();
+        });
+    
+        test('hasRole returns false when currentUser has roles but not ROLE_ADMIN', () => {
+            expect(hasRole({ loggedIn: true, root: { rolesList: ["ROLE_USER"] } }, "ROLE_ADMIN")).toBeFalsy();
+        });
+    
+        test('hasRole returns true when currentUser has ROLE_ADMIN', () => {
+            expect(hasRole({ loggedIn: true, root: { rolesList: ["ROLE_USER", "ROLE_ADMIN"] } }, "ROLE_ADMIN")).toBeTruthy();
+        });
+    
+        test('hasRole returns true when currentUser data structure has rolesList', () => {
+            expect(hasRole({ data: { root: { rolesList: ["ROLE_USER", "ROLE_ADMIN"] } } }, "ROLE_ADMIN")).toBeTruthy();
+        });
+    
+        test('hasRole returns false when currentUser data structure missing rolesList', () => {
+            expect(hasRole({ data: { root: {} } }, "ROLE_ADMIN")).toBeFalsy();
+        });
     });
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, the edit button shows up for admin users and allows the admin to click on it and it will lead to the placeholder page that says the feature is coming soon. The url link will have the correct announcement id.

## Merge Order
This PR relies on PR #48 to be merged before this one because it depends on some backend changes made in that PR to properly display the table. I rebased this branch off main first.

## Screenshots 
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
<img width="1319" alt="Screenshot 2024-05-25 at 5 19 00 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/97550852/85a4c7ca-c627-4e0a-a92d-82d3c209413b">

## Future Possibilities 
<!--What do you think this project could become? Delete if not needed.-->
Some possible points could be:
- This is the beginning/part of allowing the admin to directly edit the announcement on the frontend page.

## Validation 
<!--Steps that someone else could take to make sure everything is working-->
1. Use my dokku link: https://happycows-jasontnguyen-dev.dokku-05.cs.ucsb.edu.
2. Go on the admin tab in the nav bar and click List Commons and click Announcements button.
3. The page should now show the edit button for the announcement and click it and it leads you to a placeholder but the correct url with the announcement id.

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #52 
