### PR TITLE
F3: Add Announcements Button to the Play Page

### DIFF
--- a/frontend/src/main/components/Commons/CommonsOverview.js
+++ b/frontend/src/main/components/Commons/CommonsOverview.js
@@ -10,9 +10,12 @@ export default function CommonsOverview({ commonsPlus, currentUser }) {
     // Stryker disable next-line all
     const leaderboardButtonClick = () => { navigate("/leaderboard/" + commonsPlus.commons.id) };
     const showLeaderboard = (hasRole(currentUser, "ROLE_ADMIN") || commonsPlus.commons.showLeaderboard );
+    // Stryker disable next-line all
+    const announcementsButtonClick = () => { navigate("/announcements/" + commonsPlus.commons.id) };
+    const showAnnouncements = (hasRole(currentUser, "ROLE_ADMIN") || commonsPlus.commons.showAnnouncements );
     return (
         <Card data-testid="CommonsOverview">
-            <Card.Header as="h5">Announcements</Card.Header>
+            <Card.Header as="h5">Common Overview</Card.Header>
             <Card.Body>
                 <Row>
                     <Col>
@@ -23,6 +26,12 @@ export default function CommonsOverview({ commonsPlus, currentUser }) {
                         {showLeaderboard &&
                         (<Button variant="outline-success" data-testid="user-leaderboard-button" onClick={leaderboardButtonClick}>
                             Leaderboard
+                        </Button>)}
+                    </Col>
+                    <Col>
+                    {showAnnouncements &&
+                        (<Button variant="outline-success" data-testid="user-announcements-button" onClick={announcementsButtonClick}>
+                            Announcements
                         </Button>)}
                     </Col>
                 </Row>

--- a/frontend/src/tests/pages/AdminViewPlayPage.test.js
+++ b/frontend/src/tests/pages/AdminViewPlayPage.test.js
@@ -91,7 +91,7 @@ describe("AdminViewPlayPage tests", () => {
         );
     });
 
-    test("Make sure that both the Announcements and Welcome Farmer components show up", async () => {
+    test("Make sure that both the Common Overview and Welcome Farmer components show up", async () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -100,7 +100,7 @@ describe("AdminViewPlayPage tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByText(/Announcements/)).toBeInTheDocument();
+        expect(await screen.findByText(/Common Overview/)).toBeInTheDocument();
         expect(await screen.findByTestId("CommonsPlay")).toBeInTheDocument();
     });
 

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -120,7 +120,7 @@ describe("PlayPage tests", () => {
         await waitFor(() => expect(axiosMock.history.put.length).toBe(1));
     });
 
-    test("Make sure that both the Announcements and Welcome Farmer components show up", async () => {
+    test("Make sure that both the Common Overview and Welcome Farmer components show up", async () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -129,7 +129,7 @@ describe("PlayPage tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByText(/Announcements/)).toBeInTheDocument();
+        expect(await screen.findByText(/Common Overview/)).toBeInTheDocument();
         expect(await screen.findByTestId("CommonsPlay")).toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I implement an announcements button (just the frontend button), and change the play page header from "Announcements" to "Common Overview"

## Screenshots (Optional)
<img width="1362" alt="Screenshot 2024-05-27 at 3 20 03 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/97069739/caff9eff-6842-4661-9ac5-fc32159159c9">


## Future Possibilities (Optional)
- This is the beginning/part of showing Announcements to the user.


## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Go to the play page.
4. See if there is an announcement button and the header is Common Overview.

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/issues/60
