### PR TITLE
Feature: Endpoints for Suspending and Restoring Users

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
@@ -38,27 +38,29 @@ public class UsersController extends ApiController {
         String body = mapper.writeValueAsString(users);
         return ResponseEntity.ok().body(body);
     }
+    
+    @Operation(summary = "Suspend user using id")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/suspend")
+    public Object suspendUser(@Parameter(name = "id") @RequestParam Long id){
+        User user = userRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
+    
+        user.setSuspended(true);
+        userRepository.save(user);
+        return genericMessage("User with id %s has been suspended".formatted(id));
+    }
+    
+    @Operation(summary = "Restore user using id")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/restore")
+    public Object restoreUser(@Parameter(name = "id") @RequestParam Long id){
+        User user = userRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
+    
+        user.setSuspended(false);
+        userRepository.save(user);
+        return genericMessage("User with id %s has been restored".formatted(id));
+    }
 }
 
-@Operation(summary = "Suspend user using id")
-@PreAuthorize("hasRole('ROLE_ADMIN')")
-@PostMapping("/suspend")
-public Object suspendUser(@Parameter(name = "id") @RequestParam Long id){
-    User user = userRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
 
-    user.setSuspended(true);
-    userRepository.save(user);
-    return genericMessage("User with id %s has been suspended".formatted(id));
-}
-
-@Operation(summary = "Restore user using id")
-@PreAuthorize("hasRole('ROLE_ADMIN')")
-@PostMapping("/restore")
-public Object restoreUser(@Parameter(name = "id") @RequestParam Long id){
-    User user = userRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
-
-    user.setSuspended(false);
-    userRepository.save(user);
-    return genericMessage("User with id %s has been restored".formatted(id));
-}
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
@@ -43,7 +43,7 @@ public class UsersController extends ApiController {
 @Operation(summary = "Suspend user using id")
 @PreAuthorize("hasRole('ROLE_ADMIN')")
 @PostMapping("/suspend")
-public Object suspendUser( @Parameter(name = "id", description = "Long, id number of user to be suspended", example = "1", required = true) @RequestParam Long id){
+public Object suspendUser(@Parameter(name = "id") @RequestParam Long id){
     User user = userRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
 
     user.setSuspended(true);
@@ -54,7 +54,7 @@ public Object suspendUser( @Parameter(name = "id", description = "Long, id numbe
 @Operation(summary = "Restore user using id")
 @PreAuthorize("hasRole('ROLE_ADMIN')")
 @PostMapping("/restore")
-public Object restoreUser( @Parameter(name = "id", description = "Long, id number of user to be restored", example = "1", required = true) @RequestParam Long id){
+public Object restoreUser(@Parameter(name = "id") @RequestParam Long id){
     User user = userRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
 
     user.setSuspended(false);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
@@ -1,4 +1,5 @@
 package edu.ucsb.cs156.happiercows.controllers;
+import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
@@ -9,11 +9,14 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 
 @Tag(name="User information (admin only)")
 @RequestMapping("/api/admin/users")

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
@@ -43,8 +43,7 @@ public class UsersController extends ApiController {
 @PreAuthorize("hasRole('ROLE_ADMIN')")
 @PostMapping("/suspend")
 public Object suspendUser( @Parameter(name = "id", description = "Long, id number of user to be suspended", example = "1", required = true) @RequestParam Long id){
-    User user = userRepository.findById(id)
-    .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+    User user = userRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
 
     user.setSuspended(true);
     userRepository.save(user);
@@ -55,8 +54,7 @@ public Object suspendUser( @Parameter(name = "id", description = "Long, id numbe
 @PreAuthorize("hasRole('ROLE_ADMIN')")
 @PostMapping("/restore")
 public Object restoreUser( @Parameter(name = "id", description = "Long, id number of user to be restored", example = "1", required = true) @RequestParam Long id){
-    User user = userRepository.findById(id)
-    .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+    User user = userRepository.findById(id).orElseThrow(() -> new EntityNotFoundException(User.class, id));
 
     user.setSuspended(false);
     userRepository.save(user);

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
@@ -35,3 +35,28 @@ public class UsersController extends ApiController {
         return ResponseEntity.ok().body(body);
     }
 }
+
+@Operation(summary = "Suspend user using id")
+@PreAuthorize("hasRole('ROLE_ADMIN')")
+@PostMapping("/suspend")
+public Object suspendUser( @Parameter(name = "id", description = "Long, id number of user to be suspended", example = "1", required = true) @RequestParam Long id){
+    User user = userRepository.findById(id)
+    .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+    user.setSuspended(true);
+    userRepository.save(user);
+    return genericMessage("User with id %s has been suspended".formatted(id));
+}
+
+@Operation(summary = "Restore user using id")
+@PreAuthorize("hasRole('ROLE_ADMIN')")
+@PostMapping("/restore")
+public Object restoreUser( @Parameter(name = "id", description = "Long, id number of user to be restored", example = "1", required = true) @RequestParam Long id){
+    User user = userRepository.findById(id)
+    .orElseThrow(() -> new EntityNotFoundException(User.class, id));
+
+    user.setSuspended(false);
+    userRepository.save(user);
+    return genericMessage("User with id %s has been restored".formatted(id));
+}
+

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
@@ -30,6 +30,9 @@ public class User {
   @Builder.Default
   private Instant lastOnline = Instant.now();
 
+  @Builder.Default
+  private Boolean suspended = false;
+    
   @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST,CascadeType.REMOVE})
   @JoinTable(name = "user_commons", 
     joinColumns = @JoinColumn(name = "user_id", referencedColumnName = "id"), 

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UsersControllerTests.java
@@ -15,14 +15,18 @@ import edu.ucsb.cs156.happiercows.testconfig.TestConfig;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 
 @WebMvcTest(controllers = UsersController.class)
 @Import(TestConfig.class)
@@ -38,6 +42,8 @@ public class UsersControllerTests extends ControllerTestCase {
         .andExpect(status().is(403));
   }
 
+  private User user;
+  
   @WithMockUser(roles = { "USER" })
   @Test
   public void users__user_logged_in() throws Exception {
@@ -73,5 +79,103 @@ public class UsersControllerTests extends ControllerTestCase {
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
 
+  }
+
+  
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void testSuspendUser_success() throws Exception {
+      user = User.builder()
+              .id(1L)
+              .email("test@example.com")
+              .suspended(false)
+              .build();
+    
+      when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+      MvcResult response = mockMvc.perform(post("/api/admin/users/suspend")
+                      .param("userid", "1")
+                      .with(csrf()))
+              .andExpect(status().isOk())
+              .andReturn();
+
+      // assert
+      verify(userRepository, times(1)).findById(1L);
+      verify(userRepository, times(1)).save(user);
+      Map<String, Object> json = responseToJson(response);
+      assertEquals("User with id 1 has been suspended", json.get("message"));
+      assertEquals(true, user.getSuspended());
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void testSuspendUser_notFound() throws Exception {
+      user = User.builder()
+              .id(1L)
+              .email("test@example.com")
+              .suspended(false)
+              .build();
+    
+      when(userRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+      MvcResult response = mockMvc.perform(post("/api/admin/users/suspend")
+                      .param("userid", "1")
+                      .with(csrf()))
+              .andExpect(status().isNotFound())
+              .andReturn();
+
+      // assert
+      verify(userRepository, times(1)).findById(1L);
+      Map<String, Object> json = responseToJson(response);
+      assertEquals("User with id 1 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void testRestoreUser_success() throws Exception {
+      user = User.builder()
+              .id(1L)
+              .email("test@example.com")
+              .suspended(false)
+              .build();
+      
+      user.setSuspended(true);
+      when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+      MvcResult response = mockMvc.perform(post("/api/admin/users/restore")
+                      .param("userid", "1")
+                      .with(csrf()))
+              .andExpect(status().isOk())
+              .andReturn();
+
+      // assert
+      verify(userRepository, times(1)).findById(1L);
+      verify(userRepository, times(1)).save(user);
+      Map<String, Object> json = responseToJson(response);
+      assertEquals("User with id 1 has been restored", json.get("message"));
+      assertEquals(false, user.getSuspended());
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void testRestoreUser_notFound() throws Exception {
+      user = User.builder()
+              .id(1L)
+              .email("test@example.com")
+              .suspended(false)
+              .build();
+      
+      when(userRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+      MvcResult response = mockMvc.perform(post("/api/admin/users/restore")
+                      .param("userid", "1")
+                      .with(csrf()))
+              .andExpect(status().isNotFound())
+              .andReturn();
+
+      // assert
+      verify(userRepository, times(1)).findById(1L);
+      Map<String, Object> json = responseToJson(response);
+      assertEquals("User with id 1 not found", json.get("message"));
   }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UsersControllerTests.java
@@ -122,7 +122,7 @@ public class UsersControllerTests extends ControllerTestCase {
   public void admin_cannot_suspend_invalid_user() throws Exception {
     when(userRepository.findById(1L)).thenReturn(Optional.empty());
 
-    mockMvc.perform(post("/api/admin/users/suspend").param("userId", "1").with(csrf())).andExpect(status().isNotFound());
+    mockMvc.perform(post("/api/admin/users/suspend").param("id", "1").with(csrf())).andExpect(status().isNotFound());
   }
 
   @WithMockUser(roles={"ADMIN"})
@@ -130,6 +130,6 @@ public class UsersControllerTests extends ControllerTestCase {
   public void admin_cannot_restore_invalid_user() throws Exception {
     when(userRepository.findById(1L)).thenReturn(Optional.empty());
 
-    mockMvc.perform(post("/api/admin/users/restore").param("userId", "1").with(csrf())).andExpect(status().isNotFound());
+    mockMvc.perform(post("/api/admin/users/restore").param("id", "1").with(csrf())).andExpect(status().isNotFound());
   }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UsersControllerTests.java
@@ -117,7 +117,7 @@ public class UsersControllerTests extends ControllerTestCase {
         assertEquals("User with id 1 has been restored", json.get("message"));
   }
 
-   @WithMockUser(roles={"ADMIN"})
+  @WithMockUser(roles={"ADMIN"})
   @Test
   public void admin_cannot_suspend_invalid_user() throws Exception {
     when(userRepository.findById(1L)).thenReturn(Optional.empty());
@@ -125,7 +125,7 @@ public class UsersControllerTests extends ControllerTestCase {
     mockMvc.perform(post("/api/admin/users/suspend").param("userId", "1").with(csrf())).andExpect(status().isNotFound());
   }
 
-   @WithMockUser(roles={"ADMIN"})
+  @WithMockUser(roles={"ADMIN"})
   @Test
   public void admin_cannot_restore_invalid_user() throws Exception {
     when(userRepository.findById(1L)).thenReturn(Optional.empty());


### PR DESCRIPTION
Adds endpoints for suspending and restoring users.

**Merge Info:**
Merge after PR #59 

**Screenshots:**
<img width="1060" alt="Screenshot 2024-05-27 at 5 22 14 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/91697899/5f0e5fd5-76d9-43cf-8104-ff67436bcc46">
<img width="1073" alt="Screenshot 2024-05-27 at 5 22 25 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/91697899/e4198357-9a52-44f3-abc1-385d4c9f54cd">

**Validation:**
Dokku deployment at [https://happycows-winstonwang-dev.dokku-05.cs.ucsb.edu/](https://happycows-winstonwang-dev.dokku-05.cs.ucsb.edu/)
Test endpoints using swagger after logging in: [https://happycows-winstonwang-dev.dokku-05.cs.ucsb.edu/swagger-ui/index.html#/](https://happycows-winstonwang-dev.dokku-05.cs.ucsb.edu/swagger-ui/index.html#/)

**Tests:**
Backend Unit tests (mvn test) pass
Backend Test coverage (mvn test jacoco:report) 100%
Backend Mutation tests (mvn test pitest:mutationCoverage) 100%

Closes #41 