### PR TITLE
Added Suspended Field, Suspend Button, and Restore Button to UsersTable

### DIFF
--- a/frontend/src/fixtures/usersFixtures.js
+++ b/frontend/src/fixtures/usersFixtures.js
@@ -13,6 +13,7 @@ const usersFixtures = {
             "hostedDomain": "ucsb.edu",
             "admin": true,
             "lastOnline": "2023-06-04T18:45:16.014490Z",
+            "suspended": false,
         },
         {
             "id": 2,
@@ -27,6 +28,7 @@ const usersFixtures = {
             "hostedDomain": null,
             "admin": false,
             "lastOnline": "2023-06-04T18:45:16.014490Z",
+            "suspended": true,
         },
         {
             "id": 3,
@@ -41,6 +43,7 @@ const usersFixtures = {
             "hostedDomain": null,
             "admin": false,
             "lastOnline": "2023-06-04T18:45:16.014490Z",
+            "suspended": false,
         }
     ]
 }

--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -1,39 +1,89 @@
 import React from "react";
-import OurTable from "main/components/OurTable"
+import OurTable, {ButtonColumn} from "main/components/OurTable";
+import { useBackendMutation } from "main/utils/useBackend";
+import { cellToAxiosParamsSuspend, onSuspendSuccess, cellToAxiosParamsRestore, onRestoreSuccess } from "main/utils/usersUtils"
+import { hasRole } from "main/utils/currentUser";
 import { formatTime } from "main/utils/dateUtils";
 
-const columns = [
-    {
-        Header: 'id',
-        accessor: 'id', // accessor is the "key" in the data
-    },
-    {
-        Header: 'First Name',
-        accessor: 'givenName',
-    },
-    {
-        Header: 'Last Name',
-        accessor: 'familyName',
-    },
-    {
-        Header: 'Email',
-        accessor: 'email',
-    },
-    {
-        Header: 'Last Online',
-        id: 'lastOnline',
-        accessor: (row) => formatTime(row.lastOnline),
-    },
-    {
-        Header: 'Admin',
-        id: 'admin',
-        accessor: (row, _rowIndex) => String(row.admin) // hack needed for boolean values to show up
-    },
-];
+export default function UsersTable({ users, currentUser }) {
 
-export default function UsersTable({ users }) {
-    return <OurTable
-        data={users}
-        columns={columns}
-        testid={"UsersTable"} />;
+    // Stryker disable all : hard to test for query caching
+    const suspendMutation = useBackendMutation(
+        cellToAxiosParamsSuspend,
+        { onSuccess: onSuspendSuccess },
+        ["/api/admin/users"]
+    );
+    // Stryker restore all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const suspendCallback = async (cell) => { 
+        suspendMutation.mutate(cell);
+    }
+
+    // Stryker disable all : hard to test for query caching
+    const restoreMutation = useBackendMutation(
+        cellToAxiosParamsRestore,
+        { onSuccess: onRestoreSuccess },
+        ["/api/admin/users"]
+    );
+    // Stryker restore all 
+
+    // Stryker disable next-line all : TODO try to make a good test for this
+    const restoreCallback = async (cell) => { 
+        restoreMutation.mutate(cell);
+    }
+
+    const columns = [
+        {
+            Header: 'id',
+            accessor: 'id', // accessor is the "key" in the data
+        },
+        {
+            Header: 'First Name',
+            accessor: 'givenName',
+        },
+        {
+            Header: 'Last Name',
+            accessor: 'familyName',
+        },
+        {
+            Header: 'Email',
+            accessor: 'email',
+        },
+        {
+            Header: 'Last Online',
+            id: 'lastOnline',
+            accessor: (row) => formatTime(row.lastOnline),
+        },
+        {
+            Header: 'Admin',
+            id: 'admin',
+            accessor: (row, _rowIndex) => String(row.admin) // hack needed for boolean values to show up
+        },
+        {
+            Header: 'Suspended',
+            id: 'suspended',
+            accessor: (row, _rowIndex) => String(row.suspended) // hack needed for boolean values to show up
+        },
+    ];
+
+    const testid = "UsersTable";
+
+    const columnsIfAdmin = [
+        ...columns,
+        ButtonColumn("Suspend", "danger", suspendCallback, testid),
+        ButtonColumn("Restore", "success", restoreCallback, testid),
+    ];
+
+    const columnsToDisplay = hasRole(currentUser,"ROLE_ADMIN") ? columnsIfAdmin : columns;
+
+    return (
+    <>
+        <OurTable
+            data={users}
+            columns={columnsToDisplay}
+            testid={testid}
+        />
+    </>);
+
 };

--- a/frontend/src/main/pages/AdminUsersPage.js
+++ b/frontend/src/main/pages/AdminUsersPage.js
@@ -1,16 +1,18 @@
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import UsersTable from "main/components/Users/UsersTable"
+import { useCurrentUser } from "main/utils/currentUser";
 
 import { useUsers } from "main/utils/users";
 const AdminUsersPage = () => {
 
     const { data: users } = useUsers();
+    const { data: currentUser } = useCurrentUser();
 
     return (
         <BasicLayout>
             <h2>Users</h2>
-            <UsersTable users={users} />
+            <UsersTable users={users} currentUser={currentUser} />
         </BasicLayout>
     );
 };

--- a/frontend/src/main/utils/usersUtils.js
+++ b/frontend/src/main/utils/usersUtils.js
@@ -1,0 +1,31 @@
+import { toast } from "react-toastify";
+
+export function cellToAxiosParamsSuspend(cell) {
+    return {
+        url: "/api/admin/users/suspend",
+        method: "POST",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}
+
+export function onSuspendSuccess(message) {
+    console.log(message);
+    toast(message);
+}
+
+export function cellToAxiosParamsRestore(cell) {
+    return {
+        url: "/api/admin/users/restore",
+        method: "POST",
+        params: {
+            id: cell.row.values.id
+        }
+    }
+}
+
+export function onRestoreSuccess(message) {
+    console.log(message);
+    toast(message);
+}

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -1,44 +1,218 @@
-import { render, screen } from "@testing-library/react";
-import UsersTable from "main/components/Users/UsersTable";
-import { formatTime } from "main/utils/dateUtils";
+import { fireEvent, render, waitFor, screen } from "@testing-library/react";
 import usersFixtures from "fixtures/usersFixtures";
+import UsersTable from "main/components/Users/UsersTable";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { currentUserFixtures } from "fixtures/currentUserFixtures";
+import { cellToAxiosParamsSuspend, onSuspendSuccess, cellToAxiosParamsRestore, onRestoreSuccess } from "main/utils/usersUtils"
+import * as useBackendModule from "main/utils/useBackend";
+import { formatTime } from "main/utils/dateUtils";
 
-describe("UserTable tests", () => {
-    test("renders without crashing for empty table", () => {
-        render(
-            <UsersTable users={[]} />
-        );
+
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate
+}));
+
+describe("UsersTable tests", () => {
+  const queryClient = new QueryClient();
+
+  const expectedHeaders = ["id", "First Name", "Last Name", "Email", "Last Online", "Admin", "Suspended"];
+  const expectedFields = ["id", "givenName", "familyName", "email", "lastOnline", "admin", "suspended"];
+
+  test("renders empty table correctly", () => {
+
+    const testId = "UsersTable";
+    
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UsersTable users={[]} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
     });
 
-    test("renders without crashing for three users", () => {
-        render(
-            <UsersTable users={usersFixtures.threeUsers} />
-        );
+    expectedFields.forEach((field) => {
+      const fieldElement = screen.queryByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(fieldElement).not.toBeInTheDocument();
+    });
+  });
+
+  test("Has the expected column headers, content and buttons for admin user", () => {
+
+    const testId = "UsersTable";
+
+    // arrange
+    const currentUser = currentUserFixtures.adminUser;
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UsersTable users={usersFixtures.threeUsers} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
     });
 
-    test("Has the expected colum headers and content", () => {
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-admin`)).toHaveTextContent("true");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-lastOnline`)).toHaveTextContent(formatTime(usersFixtures.threeUsers[0].lastOnline));
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-suspended`)).toHaveTextContent("false");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-admin`)).toHaveTextContent("false");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-suspended`)).toHaveTextContent("true");
+
+    const suspendButton = screen.getByTestId(`${testId}-cell-row-0-col-Suspend-button`);
+    expect(suspendButton).toBeInTheDocument();
+    expect(suspendButton).toHaveClass("btn-danger");
+
+    const restoreButton = screen.getByTestId(`${testId}-cell-row-0-col-Restore-button`);
+    expect(restoreButton).toBeInTheDocument();
+    expect(restoreButton).toHaveClass("btn-success");
+
+  });
+
+  test("Has the expected column headers, content for ordinary user", () => {
+    // arrange
+    const currentUser = currentUserFixtures.userOnly;
+
+    const testId = "UsersTable";
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UsersTable users={usersFixtures.threeUsers} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // assert
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-admin`)).toHaveTextContent("true");
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-lastOnline`)).toHaveTextContent(formatTime(usersFixtures.threeUsers[0].lastOnline));
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-suspended`)).toHaveTextContent("false");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-admin`)).toHaveTextContent("false");
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-suspended`)).toHaveTextContent("true");
+
+    expect(screen.queryByText("Suspend")).not.toBeInTheDocument();
+    expect(screen.queryByText("Restore")).not.toBeInTheDocument();
+  });
+});
+
+describe("Button tests", () => {
+
+    const queryClient = new QueryClient();
+
+    // Mocking the delete mutation function
+    const mockMutate = jest.fn();
+    const mockUseBackendMutation = {
+      mutate: mockMutate,
+    };
+  
+    beforeEach(() => {
+      jest.spyOn(useBackendModule, "useBackendMutation").mockReturnValue(mockUseBackendMutation);
+    });
+  
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    test("Suspend button calls suspend callback", async () => {
+        // arrange
+        const currentUser = currentUserFixtures.adminUser;
+
+        const useBackendMutationSpy = jest.spyOn(useBackendModule, 'useBackendMutation');
+
+        const testId = "UsersTable";
+    
+        // act - render the component
         render(
-          <UsersTable users={usersFixtures.threeUsers}/>
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+              <UsersTable users={usersFixtures.threeUsers} currentUser={currentUser} />
+            </MemoryRouter>
+          </QueryClientProvider>
         );
     
-        const expectedHeaders = ["id", "First Name", "Last Name", "Email", "Last Online", "Admin"];
-        const expectedFields = ["id", "givenName", "familyName", "email", "lastOnline", "admin"];
-        const testId = "UsersTable";
-
-        expectedHeaders.forEach( (headerText)=> {
-            const header = screen.getByText(headerText);
-            expect(header).toBeInTheDocument();
-        });
-
-        expectedFields.forEach( (field)=> {
-          const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
-          expect(header).toBeInTheDocument();
-        });
-
-        expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-        expect(screen.getByTestId(`${testId}-cell-row-0-col-admin`)).toHaveTextContent("true");
-        expect(screen.getByTestId(`${testId}-cell-row-0-col-lastOnline`)).toHaveTextContent(formatTime(usersFixtures.threeUsers[0].lastOnline));
-        expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
-        expect(screen.getByTestId(`${testId}-cell-row-1-col-admin`)).toHaveTextContent("false");
+        const suspendButton = screen.getByTestId(`${testId}-cell-row-0-col-Suspend-button`);
+        expect(suspendButton).toBeInTheDocument();
+    
+        fireEvent.click(suspendButton);
+    
+        await waitFor(() => {
+            expect(useBackendMutationSpy).toHaveBeenCalledWith(
+              cellToAxiosParamsSuspend,
+              { onSuccess: onSuspendSuccess },
+              ["/api/admin/users"]
+            );
+          });
       });
+
+      test("Restore button calls restore callback", async () => {
+        // arrange
+        const currentUser = currentUserFixtures.adminUser;
+
+        const useBackendMutationSpy = jest.spyOn(useBackendModule, 'useBackendMutation');
+
+        const testId = "UsersTable";
+    
+        // act - render the component
+        render(
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+              <UsersTable users={usersFixtures.threeUsers} currentUser={currentUser} />
+            </MemoryRouter>
+          </QueryClientProvider>
+        );
+    
+        const restoreButton = screen.getByTestId(`${testId}-cell-row-0-col-Restore-button`);
+        expect(restoreButton).toBeInTheDocument();
+    
+        fireEvent.click(restoreButton);
+    
+        await waitFor(() => {
+            expect(useBackendMutationSpy).toHaveBeenCalledWith(
+              cellToAxiosParamsRestore,
+              { onSuccess: onRestoreSuccess },
+              ["/api/admin/users"]
+            );
+          });
+      });
+
 });

--- a/frontend/src/tests/utils/usersUtils.test.js
+++ b/frontend/src/tests/utils/usersUtils.test.js
@@ -1,0 +1,95 @@
+import { cellToAxiosParamsSuspend, onSuspendSuccess, cellToAxiosParamsRestore, onRestoreSuccess } from "main/utils/usersUtils"
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("UsersUtils", () => {
+
+    describe("onSuspendSuccess", () => {
+
+        test("It puts the message on console.log and in a toast", () => {
+            // arrange
+            const restoreConsole = mockConsole();
+
+            // act
+            onSuspendSuccess("abc");
+
+            // assert
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
+
+            restoreConsole();
+        });
+
+    });
+    describe("cellToAxiosParamsSuspend", () => {
+
+        test("It returns the correct params", () => {
+            // arrange
+            const cell = { row: { values: { id: 1 } } };
+
+            // act
+            const result = cellToAxiosParamsSuspend(cell);
+
+            // assert
+            expect(result).toEqual({
+                url: "/api/admin/users/suspend",
+                method: "POST",
+                params: { id: 1 }
+            });
+        });
+
+    });
+
+    describe("onRestoreSuccess", () => {
+
+        test("It puts the message on console.log and in a toast", () => {
+            // arrange
+            const restoreConsole = mockConsole();
+
+            // act
+            onRestoreSuccess("abc");
+
+            // assert
+            expect(mockToast).toHaveBeenCalledWith("abc");
+            expect(console.log).toHaveBeenCalled();
+            const message = console.log.mock.calls[0][0];
+            expect(message).toMatch("abc");
+
+            restoreConsole();
+        });
+
+    });
+    describe("cellToAxiosParamsRestore", () => {
+
+        test("It returns the correct params", () => {
+            // arrange
+            const cell = { row: { values: { id: 1 } } };
+
+            // act
+            const result = cellToAxiosParamsRestore(cell);
+
+            // assert
+            expect(result).toEqual({
+                url: "/api/admin/users/restore",
+                method: "POST",
+                params: { id: 1 }
+            });
+        });
+    });
+});
+
+
+
+
+


### PR DESCRIPTION
## Overview
In this pr we allow people with access to the usersTable to see if a certain user is suspended or not. If the person with access to a table is an admin, they also have access to a "Suspend" and a "Restore" button that changes that row's user's suspend value

## Screenshots
This is the usersTable while I'm logged into an admin account
![image](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/97640757/2337facf-d1b9-4c5f-855d-94909d0ff195)

## Dependencies
PR #63 and PR #59 must be merged before this PR since this PR uses the suspend endpoints and suspend fields in the user object from those PRs respectively.

## Future Possibilities 
This is the first frontend part of the suspend EPIC, the issue following this will add a modal for confirming a suspension or restoration of a user

## Validation
1. Visit my dokku deployment here: https://happycows-garvinyoung-dev2.dokku-05.cs.ucsb.edu/
2. Login using an admin account
3. Navigate to usersTable (go to Admin dropdown on navbar then click on "Users"
4. Check if you can see the "Suspend" and "Restore" buttons and play around with them, to see the "Suspended" field with an updated value, you will need to refresh the page to rerender the table. Additionally, if you use this on another app with existing members, the "Suspended" field will return null since those users were created before the suspended field was added. Simply click on one of the buttons to update their "Suspended" field.

## Tests
Made tests for `usersUtils.js` and expanded existing tests and well as making new ones in `UsersTable.test.js` to cover the correct rendering of the new columns in the table as well as ensuring the buttons function correctly on click.

## Linked Issues
<!--Issues related to the PR-->
Closes #42
