### PR TITLE
Implemented Comfirmation Modal for Suspend & Restore Button in userTable

### DIFF
--- a/frontend/src/main/components/Users/UsersTable.js
+++ b/frontend/src/main/components/Users/UsersTable.js
@@ -1,11 +1,18 @@
-import React from "react";
+import React,  {useState} from "react";
 import OurTable, {ButtonColumn} from "main/components/OurTable";
 import { useBackendMutation } from "main/utils/useBackend";
 import { cellToAxiosParamsSuspend, onSuspendSuccess, cellToAxiosParamsRestore, onRestoreSuccess } from "main/utils/usersUtils"
 import { hasRole } from "main/utils/currentUser";
 import { formatTime } from "main/utils/dateUtils";
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
 
 export default function UsersTable({ users, currentUser }) {
+
+    const [showModalSuspend, setShowModalSuspend] = useState(false);
+    const [cellToSuspend, setCellToSuspend] = useState(null);
+    const [showModalRestore, setShowModalRestore] = useState(false);
+    const [cellToRestore, setCellToRestore] = useState(null);
 
     // Stryker disable all : hard to test for query caching
     const suspendMutation = useBackendMutation(
@@ -16,9 +23,15 @@ export default function UsersTable({ users, currentUser }) {
     // Stryker restore all 
 
     // Stryker disable next-line all : TODO try to make a good test for this
-    const suspendCallback = async (cell) => { 
-        suspendMutation.mutate(cell);
+    const suspendCallback = async (cell) => {
+        setCellToSuspend(cell);
+        setShowModalSuspend(true);
     }
+
+    const confirmSuspend = async (cell) => {
+        suspendMutation.mutate(cell);
+        setShowModalSuspend(false);
+    };
 
     // Stryker disable all : hard to test for query caching
     const restoreMutation = useBackendMutation(
@@ -29,9 +42,15 @@ export default function UsersTable({ users, currentUser }) {
     // Stryker restore all 
 
     // Stryker disable next-line all : TODO try to make a good test for this
-    const restoreCallback = async (cell) => { 
-        restoreMutation.mutate(cell);
+    const restoreCallback = async (cell) => {
+        setCellToRestore(cell);
+        setShowModalRestore(true);
     }
+
+    const confirmRestore = async (cell) => {
+        restoreMutation.mutate(cell);
+        setShowModalRestore(false);
+    };
 
     const columns = [
         {
@@ -77,6 +96,42 @@ export default function UsersTable({ users, currentUser }) {
 
     const columnsToDisplay = hasRole(currentUser,"ROLE_ADMIN") ? columnsIfAdmin : columns;
 
+    const usersModalSuspend = (
+        <Modal data-testid="UsersTable-Modal" show={showModalSuspend} onHide={() => setShowModalSuspend(false)}>
+            <Modal.Header closeButton>
+                <Modal.Title>Confirm Suspension</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                Are you sure you want to suspend this user?            
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="secondary" data-testid="UsersTable-SuspendModal-Cancel" onClick={() => setShowModalSuspend(false)}>
+                    Leave this User as is
+                </Button>
+                <Button variant="danger" data-testid="UsersTable-Modal-Suspend" onClick={() => confirmSuspend(cellToSuspend)}>
+                    Suspend this User
+                </Button>
+            </Modal.Footer>
+        </Modal> );
+
+    const usersModalRestore = (
+        <Modal data-testid="UsersTable-Modal" show={showModalRestore} onHide={() => setShowModalRestore(false)}>
+            <Modal.Header closeButton>
+                <Modal.Title>Confirm Restoration</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                Are you sure you want to restore this user?            
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="secondary" data-testid="UsersTable-RestoreModal-Cancel" onClick={() => setShowModalRestore(false)}>
+                    Leave this User as is
+                </Button>
+                <Button variant="success" data-testid="UsersTable-Modal-Restore" onClick={() => confirmRestore(cellToRestore)}>
+                    Restore this User
+                </Button>
+            </Modal.Footer>
+        </Modal> );
+
     return (
     <>
         <OurTable
@@ -84,6 +139,8 @@ export default function UsersTable({ users, currentUser }) {
             columns={columnsToDisplay}
             testid={testid}
         />
+        {hasRole(currentUser,"ROLE_ADMIN") && usersModalSuspend}
+        {hasRole(currentUser,"ROLE_ADMIN") && usersModalRestore}
     </>);
 
 };

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -135,84 +135,268 @@ describe("UsersTable tests", () => {
   });
 });
 
-describe("Button tests", () => {
 
-    const queryClient = new QueryClient();
+describe("Modal tests", () => {
 
-    // Mocking the delete mutation function
-    const mockMutate = jest.fn();
-    const mockUseBackendMutation = {
-      mutate: mockMutate,
-    };
+  const queryClient = new QueryClient();
+
+  // Mocking the delete mutation function
+  const mockMutate = jest.fn();
+  const mockUseBackendMutation = {
+    mutate: mockMutate,
+  };
+
+  beforeEach(() => {
+    jest.spyOn(useBackendModule, "useBackendMutation").mockReturnValue(mockUseBackendMutation);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+
+
+  test("Clicking Suspend button opens the modal for adminUser", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UsersTable users={usersFixtures.threeUsers} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // Verify that the modal is hidden by checking for the absence of the "modal-open" class
+    await waitFor(() => {
+      expect(document.body).not.toHaveClass('modal-open');
+    });
+
+    const suspendButton = screen.getByTestId("UsersTable-cell-row-0-col-Suspend-button");
+    fireEvent.click(suspendButton);
+
+    // Verify that the modal is shown by checking for the "modal-open" class
+    await waitFor(() => {
+      expect(document.body).toHaveClass('modal-open');
+      expect(screen.queryByText("Are you sure you want to suspend this user?")).toBeInTheDocument();
+    });
+  });
+
+  test("Clicking Restore button opens the modal for adminUser", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UsersTable users={usersFixtures.threeUsers} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // Verify that the modal is hidden by checking for the absence of the "modal-open" class
+    await waitFor(() => {
+      expect(document.body).not.toHaveClass('modal-open');
+    });
+
+    const restoreButton = screen.getByTestId("UsersTable-cell-row-0-col-Restore-button");
+    fireEvent.click(restoreButton);
+
+    // Verify that the modal is shown by checking for the "modal-open" class
+    await waitFor(() => {
+      expect(document.body).toHaveClass('modal-open');
+      expect(screen.queryByText("Are you sure you want to restore this user?")).toBeInTheDocument();
+    });
+  });
+
+
+
+  test("Clicking Suspend this User button suspends the user", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    // https://www.chakshunyu.com/blog/how-to-spy-on-a-named-import-in-jest/
+    const useBackendMutationSpy = jest.spyOn(useBackendModule, 'useBackendMutation');
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UsersTable users={usersFixtures.threeUsers} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const suspendButton = screen.getByTestId("UsersTable-cell-row-0-col-Suspend-button");
+    fireEvent.click(suspendButton);
+
+    const suspendUserButton = await screen.findByTestId("UsersTable-Modal-Suspend");
+    fireEvent.click(suspendUserButton);
+
+    await waitFor(() => {
+      expect(useBackendMutationSpy).toHaveBeenCalledWith(
+        cellToAxiosParamsSuspend,
+        { onSuccess: onSuspendSuccess },
+        ["/api/admin/users"]
+      );
+    });
+
+    // Verify that the modal is hidden by checking for the absence of the "modal-open" class
+    await waitFor(() => {
+      expect(document.body).not.toHaveClass('modal-open');
+      expect(screen.queryByText("Are you sure you want to suspend this user?")).not.toBeInTheDocument();
+    });
+  });
+
+  test("Clicking Restore this User button restores the user", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    // https://www.chakshunyu.com/blog/how-to-spy-on-a-named-import-in-jest/
+    const useBackendMutationSpy = jest.spyOn(useBackendModule, 'useBackendMutation');
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UsersTable users={usersFixtures.threeUsers} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const restoreButton = screen.getByTestId("UsersTable-cell-row-0-col-Restore-button");
+    fireEvent.click(restoreButton);
+
+    const restoreUserButton = await screen.findByTestId("UsersTable-Modal-Restore");
+    fireEvent.click(restoreUserButton);
+
+    await waitFor(() => {
+      expect(useBackendMutationSpy).toHaveBeenCalledWith(
+        cellToAxiosParamsRestore,
+        { onSuccess: onRestoreSuccess },
+        ["/api/admin/users"]
+      );
+    });
+
+    // Verify that the modal is hidden by checking for the absence of the "modal-open" class
+    await waitFor(() => {
+      expect(document.body).not.toHaveClass('modal-open');
+      expect(screen.queryByText("Are you sure you want to restore this user?")).not.toBeInTheDocument();
+    });
+  });
+
+
+
+  test("Clicking Leave this User as is button cancels the suspension", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UsersTable users={usersFixtures.threeUsers} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const suspendButton = screen.getByTestId("UsersTable-cell-row-0-col-Suspend-button");
+    fireEvent.click(suspendButton);
+
+    const cancelSuspendButton = await screen.findByTestId("UsersTable-SuspendModal-Cancel");
+    fireEvent.click(cancelSuspendButton);
+
+    // Verify that the modal is hidden by checking for the absence of the "modal-open" class
+    await waitFor(() => {
+      expect(document.body).not.toHaveClass('modal-open');
+    });
+
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  test("Clicking Leave this User as is button cancels the restoration", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UsersTable users={usersFixtures.threeUsers} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    const restoreButton = screen.getByTestId("UsersTable-cell-row-0-col-Restore-button");
+    fireEvent.click(restoreButton);
+
+    const cancelSuspendButton = await screen.findByTestId("UsersTable-RestoreModal-Cancel");
+    fireEvent.click(cancelSuspendButton);
+
+    // Verify that the modal is hidden by checking for the absence of the "modal-open" class
+    await waitFor(() => {
+      expect(document.body).not.toHaveClass('modal-open');
+    });
+
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+
+
+  test("Pressing the escape key on the modal cancels the suspension", async () => {
+    const currentUser = currentUserFixtures.adminUser;
   
-    beforeEach(() => {
-      jest.spyOn(useBackendModule, "useBackendMutation").mockReturnValue(mockUseBackendMutation);
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UsersTable users={usersFixtures.threeUsers} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  
+    // Click the delete button to open the modal
+    const suspendButton = screen.getByTestId("UsersTable-cell-row-0-col-Suspend-button");
+    fireEvent.click(suspendButton);
+  
+    // Check that the modal is displayed by checking for the "modal-open" class in the body
+    expect(document.body).toHaveClass('modal-open');
+  
+    // Click the close button
+    const closeButton = screen.getByLabelText('Close');
+    fireEvent.click(closeButton);
+  
+    // Verify that the modal is hidden by checking for the absence of the "modal-open" class
+    await waitFor(() => {
+      expect(document.body).not.toHaveClass('modal-open');
     });
   
-    afterEach(() => {
-      jest.clearAllMocks();
+    // Assert that the delete mutation was not called
+    // (you'll need to replace `mockMutate` with the actual reference to the mutation in your code)
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
+
+  test("Pressing the escape key on the modal cancels the restoration", async () => {
+    const currentUser = currentUserFixtures.adminUser;
+  
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <UsersTable users={usersFixtures.threeUsers} currentUser={currentUser} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  
+    // Click the delete button to open the modal
+    const restoreButton = screen.getByTestId("UsersTable-cell-row-0-col-Restore-button");
+    fireEvent.click(restoreButton);
+  
+    // Check that the modal is displayed by checking for the "modal-open" class in the body
+    expect(document.body).toHaveClass('modal-open');
+  
+    // Click the close button
+    const closeButton = screen.getByLabelText('Close');
+    fireEvent.click(closeButton);
+  
+    // Verify that the modal is hidden by checking for the absence of the "modal-open" class
+    await waitFor(() => {
+      expect(document.body).not.toHaveClass('modal-open');
     });
+  
+    // Assert that the delete mutation was not called
+    // (you'll need to replace `mockMutate` with the actual reference to the mutation in your code)
+    expect(mockMutate).not.toHaveBeenCalled();
+  });
 
-    test("Suspend button calls suspend callback", async () => {
-        // arrange
-        const currentUser = currentUserFixtures.adminUser;
-
-        const useBackendMutationSpy = jest.spyOn(useBackendModule, 'useBackendMutation');
-
-        const testId = "UsersTable";
-    
-        // act - render the component
-        render(
-          <QueryClientProvider client={queryClient}>
-            <MemoryRouter>
-              <UsersTable users={usersFixtures.threeUsers} currentUser={currentUser} />
-            </MemoryRouter>
-          </QueryClientProvider>
-        );
-    
-        const suspendButton = screen.getByTestId(`${testId}-cell-row-0-col-Suspend-button`);
-        expect(suspendButton).toBeInTheDocument();
-    
-        fireEvent.click(suspendButton);
-    
-        await waitFor(() => {
-            expect(useBackendMutationSpy).toHaveBeenCalledWith(
-              cellToAxiosParamsSuspend,
-              { onSuccess: onSuspendSuccess },
-              ["/api/admin/users"]
-            );
-          });
-      });
-
-      test("Restore button calls restore callback", async () => {
-        // arrange
-        const currentUser = currentUserFixtures.adminUser;
-
-        const useBackendMutationSpy = jest.spyOn(useBackendModule, 'useBackendMutation');
-
-        const testId = "UsersTable";
-    
-        // act - render the component
-        render(
-          <QueryClientProvider client={queryClient}>
-            <MemoryRouter>
-              <UsersTable users={usersFixtures.threeUsers} currentUser={currentUser} />
-            </MemoryRouter>
-          </QueryClientProvider>
-        );
-    
-        const restoreButton = screen.getByTestId(`${testId}-cell-row-0-col-Restore-button`);
-        expect(restoreButton).toBeInTheDocument();
-    
-        fireEvent.click(restoreButton);
-    
-        await waitFor(() => {
-            expect(useBackendMutationSpy).toHaveBeenCalledWith(
-              cellToAxiosParamsRestore,
-              { onSuccess: onRestoreSuccess },
-              ["/api/admin/users"]
-            );
-          });
-      });
 
 });

--- a/frontend/src/tests/components/Users/UsersTable.test.js
+++ b/frontend/src/tests/components/Users/UsersTable.test.js
@@ -178,8 +178,9 @@ describe("Modal tests", () => {
     // Verify that the modal is shown by checking for the "modal-open" class
     await waitFor(() => {
       expect(document.body).toHaveClass('modal-open');
-      expect(screen.queryByText("Are you sure you want to suspend this user?")).toBeInTheDocument();
     });
+    expect(screen.getByText("Are you sure you want to suspend this user?")).toBeInTheDocument();
+
   });
 
   test("Clicking Restore button opens the modal for adminUser", async () => {
@@ -204,8 +205,9 @@ describe("Modal tests", () => {
     // Verify that the modal is shown by checking for the "modal-open" class
     await waitFor(() => {
       expect(document.body).toHaveClass('modal-open');
-      expect(screen.queryByText("Are you sure you want to restore this user?")).toBeInTheDocument();
     });
+    expect(screen.getByText("Are you sure you want to restore this user?")).toBeInTheDocument();
+
   });
 
 
@@ -241,8 +243,9 @@ describe("Modal tests", () => {
     // Verify that the modal is hidden by checking for the absence of the "modal-open" class
     await waitFor(() => {
       expect(document.body).not.toHaveClass('modal-open');
-      expect(screen.queryByText("Are you sure you want to suspend this user?")).not.toBeInTheDocument();
     });
+    expect(screen.queryByText("Are you sure you want to suspend this user?")).not.toBeInTheDocument();
+
   });
 
   test("Clicking Restore this User button restores the user", async () => {
@@ -276,8 +279,9 @@ describe("Modal tests", () => {
     // Verify that the modal is hidden by checking for the absence of the "modal-open" class
     await waitFor(() => {
       expect(document.body).not.toHaveClass('modal-open');
-      expect(screen.queryByText("Are you sure you want to restore this user?")).not.toBeInTheDocument();
     });
+    expect(screen.queryByText("Are you sure you want to restore this user?")).not.toBeInTheDocument();
+
   });
 
 


### PR DESCRIPTION
## Overview
In this PR, we added comfirmation modals for the suspend and restore buttons in the user table to limit accidental suspensions or restorations of users.

## Screenshots
Images of the modals, suspend on the left, restore on the right
![image](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/97640757/3b436fa1-8965-4b9d-8760-bde17c22a195)

## Dependencies
PR #65 and PR #63 must be merged before this PR, they added the additional columns for the users table while connecting the buttons to the api and created the api endpoints respectively.

## Future Possibilities
- currently the suspended field in the table isn't getting updated after a suspension or restoration since the page needs to rerender for it to apply, a quick issue could be made from this

## Validation
- Visit my dokku deployment here: https://happycows-garvinyoung-dev3.dokku-05.cs.ucsb.edu/
- Login using an admin account and navigate to the users table
- Play around with the buttons ensuring the modals open and close correctly and you can still change a user's suspended field using them

## Tests
Added modal tests for the button modals testing modal opening, modal closing, and suspend/restore button works as intended

## Linked Issues
Closes #43
