### PR TITLE
Feature: Create an Announcement Through the Frontend

### DIFF
--- a/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
@@ -1,12 +1,69 @@
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import AnnouncementsForm from "main/components/Announcement/AnnouncementForm";
+import { Navigate } from 'react-router-dom'
+import { toast } from "react-toastify"
+import { useBackend} from "main/utils/useBackend";
+import { useBackendMutation } from "main/utils/useBackend";
+import { useParams } from "react-router-dom";
 
-export default function AdminCreateAnnouncementsPage() {
+const AdminCreateAnnouncement = () => {
+
+    let { commonsId } = useParams();
+
+    // Stryker disable all
+    const { data: commonsPlus } = useBackend(
+        [`/api/commons/plus?id=${commonsId}`],
+        {
+            method: "GET",
+            url: "/api/commons/plus",
+            params: {
+                id: commonsId,
+            },
+        }
+    );
+    const commonsName = commonsPlus?.commons.name;
+
+     const objectToAxiosParams = (newAnnouncement) => ({        
+        url: "/api/announcements/post",
+        method: "POST",
+        params: {
+            commonsId: newAnnouncement.commonsId,
+            startDate: newAnnouncement.startDate,
+            endDate: newAnnouncement.endDate,
+            announcementText: newAnnouncement.announcementText
+        }
+    });
+
+    const onSuccess = (newAnnouncement) => {
+        toast(`New Announcement Created - commonsId: ${commonsId} id: ${newAnnouncement.id} startDate: ${newAnnouncement.startDate} endDate: ${newAnnouncement.endDate} announcmentText: ${newAnnouncement.announcementText}`);
+    }
+    
+      // Stryker disable all
+    const mutation = useBackendMutation(
+        objectToAxiosParams,
+        { onSuccess },
+        // Stryker disable next-line all : hard to set up test for caching
+        [`/api/announcements/getbycommonsid?commonsId=${commonsId}`]
+    );
+    // Stryker restore all
+
+    const submitAction = async (data) => {
+        mutation.mutate({ ...data, commonsId });
+    }
+
+    if (mutation.isSuccess) {
+        return <Navigate to={`/admin/announcements/${commonsId}`} />
+    }
+
     return (
         <BasicLayout>
-            <div className="pt-2">
-                <h1>Feature Coming Soon</h1>
-            </div>
+            <h2>Create Announcement for {commonsName}</h2>
+            <AnnouncementsForm
+                submitAction={submitAction}
+            />
         </BasicLayout>
-    )
-}
+    );
+};
+
+export default AdminCreateAnnouncement;

--- a/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
@@ -1,25 +1,70 @@
-import { render, screen } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
+import {QueryClient, QueryClientProvider} from "react-query";
+import {MemoryRouter} from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
-import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import {apiCurrentUserFixtures} from "fixtures/currentUserFixtures";
+import {systemInfoFixtures} from "fixtures/systemInfoFixtures";
+import healthUpdateStrategyListFixtures from "../../fixtures/healthUpdateStrategyListFixtures";
 import AdminCreateAnnouncementsPage from "main/pages/AdminCreateAnnouncementsPage";
 
-describe("AdminCreateAnnouncements tests", () => {
-    const queryClient = new QueryClient();
-    const axiosMock = new AxiosMockAdapter(axios);
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({ 
+            commonsId: "1"
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; },
+    };
+});
 
-    beforeEach(()=>{
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("AdminCreateAnnouncementsPage tests", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
+    const queryClient = new QueryClient();
+
+    beforeEach(() => {
         axiosMock.reset();
         axiosMock.resetHistory();
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/commons/all-health-update-strategies")
+            .reply(200, healthUpdateStrategyListFixtures.simple);
+        axiosMock.onGet("/api/commons", { params: { id: 1 } }).reply(200, {
+            id: 1,
+            name: "Sample Commons",
+        });
+        axiosMock.onGet("/api/commons/all").reply(200, [
+            {
+                id: 1,
+                name: "Sample Commons",
+            },
+        ]);
+
+        axiosMock.onGet("/api/commons/plus", { params: { id: 1 } }).reply(200, {
+            commons: {
+                id: 1,
+                name: "Sample Commons",
+            },
+            totalPlayers: 5,
+            totalCows: 5,
+        });
     });
 
-    test("renders correctly without crashing", async () => {
+    test("renders without crashing", async () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -28,7 +73,59 @@ describe("AdminCreateAnnouncements tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByText("Feature Coming Soon")).toBeInTheDocument();
+        expect(await screen.findByTestId("AnnouncementForm-startDate")).toBeInTheDocument();
+    });
+
+    test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+
+        const queryClient = new QueryClient();
+        const announcement = {
+            id: 1,
+            commonsId: 1,
+            startDate: "2024-05-28T00:00",
+            endDate: "2024-06-28T00:00",
+            announcementText: "test"
+        };
+
+        axiosMock.onPost("/api/announcements/post").reply(200, announcement);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminCreateAnnouncementsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId("AnnouncementForm-startDate")).toBeInTheDocument();
+        });
+
+        const startDateField = screen.getByTestId("AnnouncementForm-startDate");
+        const endDateField = screen.getByTestId("AnnouncementForm-endDate");
+        const announcementTextField = screen.getByTestId("AnnouncementForm-announcementText");
+        const submitButton = screen.getByTestId("AnnouncementForm-submit");
+
+        fireEvent.change(startDateField, { target: { value: '2024-05-28T00:00' } });
+        fireEvent.change(endDateField, { target: { value: '2024-06-28T00:00' } });
+        fireEvent.change(announcementTextField, { target: { value: 'Great' } });
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual(
+            {
+                "commonsId": "1",
+                "startDate": "2024-05-28T00:00",
+                "endDate": "2024-06-28T00:00",
+                "announcementText": "Great"
+        });
+
+        expect(mockToast).toBeCalledWith("New Announcement Created - commonsId: 1 id: 1 startDate: 2024-05-28T00:00 endDate: 2024-06-28T00:00 announcmentText: test");
+        expect(mockNavigate).toBeCalledWith({ "to": "/admin/announcements/1" });
     });
 
 });

--- a/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
@@ -108,7 +108,7 @@ describe("AdminCreateAnnouncementsPage tests", () => {
 
         fireEvent.change(startDateField, { target: { value: '2024-05-28T00:00' } });
         fireEvent.change(endDateField, { target: { value: '2024-06-28T00:00' } });
-        fireEvent.change(announcementTextField, { target: { value: 'Great' } });
+        fireEvent.change(announcementTextField, { target: { value: 'test' } });
 
         expect(submitButton).toBeInTheDocument();
 
@@ -121,7 +121,7 @@ describe("AdminCreateAnnouncementsPage tests", () => {
                 "commonsId": "1",
                 "startDate": "2024-05-28T00:00",
                 "endDate": "2024-06-28T00:00",
-                "announcementText": "Great"
+                "announcementText": "test"
         });
 
         expect(mockToast).toBeCalledWith("New Announcement Created - commonsId: 1 id: 1 startDate: 2024-05-28T00:00 endDate: 2024-06-28T00:00 announcmentText: test");


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we add an feature that allows an admin to create an announcement for a specific commons by filling out the Announcement Form.

## Screenshots
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
<img width="1353" alt="Screenshot 2024-05-28 at 10 23 48 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/97550852/520135e0-d3d1-44f7-898d-3d7e16854b12">
<img width="636" alt="Screenshot 2024-05-28 at 10 24 44 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/97550852/0c57c38f-a252-4990-98c1-816e170eab05">

## Validation 
<!--Steps that someone else could take to make sure everything is working-->
1. Dokku Link: https://happycows-jasontnguyen-dev1.dokku-05.cs.ucsb.edu
2. Go to the Admin tab in the nav bar then List Commons and then the blue Announcements button for any of the commons.
3. Click Create Announcement and fill out the form
4. Confirm a new announcement is made by checking if it shows up in the table and on swagger by using the GET api.

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #22 
