### PR TITLE
Feature: Edit Announcement Through Frontend

### DIFF
--- a/frontend/src/main/pages/AdminEditAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminEditAnnouncementsPage.js
@@ -1,11 +1,67 @@
-import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import AnnouncementForm from "main/components/Announcement/AnnouncementForm";
+import { Navigate } from 'react-router-dom'
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
 export default function AdminEditAnnouncementsPage() {
+    let { announcementId } = useParams();
+
+    const { data: announcement, _error, _status } =
+        useBackend(
+            // Stryker disable next-line all : don't test internal caching of React Query
+            [`/api/announcements/getbyid?id=${announcementId}`],
+            {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+                method: "GET",
+                url: `/api/announcements/getbyid`,
+                params: {
+                    id: announcementId
+                }
+            }
+        );
+    const commonsId = announcement?.commonsId
+    
+    const objectToAxiosPutParams = (announcement) => ({
+        url: "/api/announcements/put",
+        method: "PUT",
+        params: {
+            id: announcement.id,
+            commonsId: announcement.commonsId,
+            startDate: announcement.startDate,
+            endDate: announcement.endDate,
+            announcementText: announcement.announcementText,
+        },
+    });
+
+    const onSuccess = (announcement) => {
+        toast(`Announcement Updated - id: ${announcement.id} announcementText: ${announcement.announcementText}`);
+    }
+
+    const mutation = useBackendMutation(
+        objectToAxiosPutParams,
+        { onSuccess },
+        // Stryker disable next-line all : hard to set up test for caching
+        [`/api/announcements/getbyid?id=${announcementId}`]
+    );
+
+    const { isSuccess } = mutation
+
+    const submitAction = async (data) => {
+        mutation.mutate({ ...data, announcementId });
+    }
+
+    if (isSuccess) {
+        return <Navigate to={`/admin/announcements/${commonsId}` }/>
+    }
+
     return (
         <BasicLayout>
             <div className="pt-2">
-                <h1>Feature Coming Soon</h1>
+                <h1>Edit Announcement {announcementId}</h1>
+                {announcement &&
+                    <AnnouncementForm initialContents={announcement} submitAction={submitAction} buttonLabel="Update" />
+                }
             </div>
         </BasicLayout>
     )

--- a/frontend/src/tests/pages/AdminEditAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminEditAnnouncementsPage.test.js
@@ -1,34 +1,136 @@
-import { render, screen } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
+import {QueryClient, QueryClientProvider} from "react-query";
+import {MemoryRouter} from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-
-import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
-import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import {apiCurrentUserFixtures} from "fixtures/currentUserFixtures";
+import {systemInfoFixtures} from "fixtures/systemInfoFixtures";
 import AdminEditAnnouncementsPage from "main/pages/AdminEditAnnouncementsPage";
 
-describe("AdminCreateAnnouncements tests", () => {
-    const queryClient = new QueryClient();
-    const axiosMock = new AxiosMockAdapter(axios);
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
-    beforeEach(()=>{
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            announcementId: 1
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("AdminEditAnnouncementsPage tests", () => {
+    describe("tests where backend is working normally", () => {
+        
+        const axiosMock = new AxiosMockAdapter(axios);
+
+        beforeEach(() => {
+            axiosMock.reset();
+            axiosMock.resetHistory();
+            axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+            axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+            axiosMock.onGet("/api/announcements/getbyid", { params: { id: 1 } }).reply(200, {
+                "id": 1,
+                "commonsId": 1,
+                "startDate": "2024-05-28T00:00",
+                "endDate": "2024-06-28T00:00",
+                "announcementText": "test",
+            });
+            axiosMock.onPut('/api/announcements/put').reply(200, {
+                "id": 1,
+                "commonsId": 1,
+                "startDate": "2024-05-29T00:00",
+                "endDate": "2023-06-29T00:00",
+                "announcementText": "new test",
+            });
+        });
+
+        const queryClient = new QueryClient();
+
+        test("renders without crashing", () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <AdminEditAnnouncementsPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+        });
+
+        test("Is populated with the data provided", async () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <AdminEditAnnouncementsPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            await screen.findByTestId("AnnouncementForm-startDate");
+
+            const startDateField = screen.getByLabelText(/Start Date/);
+            const endDateField = screen.getByLabelText(/End Date/);
+            const announcementTextField = screen.getByLabelText(/Announcement/);
+
+            expect(startDateField).toHaveValue("2024-05-28T00:00");
+            expect(endDateField).toHaveValue("2024-06-28T00:00");
+            expect(announcementTextField).toHaveValue("test");
+
+        });
+
+        test("Changes when you click Update", async () => {
+            render(
+                <QueryClientProvider client={queryClient}>
+                    <MemoryRouter>
+                        <AdminEditAnnouncementsPage />
+                    </MemoryRouter>
+                </QueryClientProvider>
+            );
+
+            expect(await screen.findByLabelText(/Start Date/)).toBeInTheDocument();
+
+            const startDateField = screen.getByLabelText(/Start Date/);
+            const endDateField = screen.getByLabelText(/End Date/);
+            const announcementTextField = screen.getByLabelText(/Announcement/);
+
+            expect(startDateField).toHaveValue("2024-05-28T00:00");
+            expect(endDateField).toHaveValue("2024-06-28T00:00");
+            expect(announcementTextField).toHaveValue("test");
+
+            const submitButton = screen.getByText("Update");
+
+            expect(submitButton).toBeInTheDocument();
+
+            fireEvent.change(startDateField, { target: { value: "2024-05-29T00:00" } })
+            fireEvent.change(endDateField, { target: { value: "2024-06-29T00:00" } })
+            fireEvent.change(announcementTextField, { target: { value: "new test" } })
+
+            fireEvent.click(submitButton);
+
+            await waitFor(() => expect(mockToast).toHaveBeenCalled());
+            expect(mockToast).toBeCalledWith("Announcement Updated - id: 1 announcementText: new test");
+            expect(mockNavigate).toBeCalledWith({ "to": "/admin/announcements/1" });
+
+            expect(axiosMock.history.put.length).toBe(1); 
+            expect(axiosMock.history.put[0].params).toEqual(
+                { 
+                    id: 1, 
+                    commonsId: 1, 
+                    startDate: "2024-05-29T00:00", 
+                    endDate: "2024-06-29T00:00", 
+                    announcementText: "new test" 
+                });
+        });
     });
-
-    test("renders correctly without crashing", async () => {
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <AdminEditAnnouncementsPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-        expect(await screen.findByText("Feature Coming Soon")).toBeInTheDocument();
-    });
-
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we add an feature that allows an admin to edit an announcement for a specific commons by filling out the Announcement Form.

## Merge Order
You should merge PR #56 first because it contains fixes that allow admins to see the edit button.

## Screenshots 
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
<img width="1341" alt="Screenshot 2024-05-29 at 2 36 32 AM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/97550852/18d13682-24bc-4ea4-9327-55a7b433c490">
<img width="823" alt="Screenshot 2024-05-29 at 2 36 49 AM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/97550852/67994ec5-ec99-4117-96c9-4fd62f0a3716">

## Validation 
<!--Steps that someone else could take to make sure everything is working-->
1. Dokku Link: https://happycows-jasontnguyen-dev2.dokku-05.cs.ucsb.edu
2. Go to the Admin tab in the nav bar then List Commons and then the blue Announcements button for any of the commons.
3. Click Edit on any of the announcements and fill out the form
4. Confirm the edited announcement is made by checking if it shows up in the table correctly and on swagger by using the GET api.

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #23
