### PR TITLE
BUG: Fix Toast Spam for Access Denied

### DIFF
--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -8,7 +8,7 @@ import CommonsPlay from "main/components/Commons/CommonsPlay";
 import FarmStats from "main/components/Commons/FarmStats";
 import ManageCows from "main/components/Commons/ManageCows";
 import Profits from "main/components/Commons/Profits";
-import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { useBackendConsole, useBackendMutation } from "main/utils/useBackend";
 import { hasRole } from "main/utils/currentUser";
 import { useCurrentUser } from "main/utils/currentUser";
 import Background from "../../assets/PlayPageBackground.jpg";
@@ -31,7 +31,7 @@ export default function PlayPage() {
     };
 
     // Stryker disable all
-    const { data: userCommons } = useBackend(
+    const { data: userCommons } = useBackendConsole(
         [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`],
         {
             method: "GET",
@@ -44,7 +44,7 @@ export default function PlayPage() {
     // Stryker restore all
 
     // Stryker disable all
-    const { data: commonsPlus } = useBackend(
+    const { data: commonsPlus } = useBackendConsole(
         [`/api/commons/plus?id=${commonsId}`],
         {
             method: "GET",
@@ -57,7 +57,7 @@ export default function PlayPage() {
     // Stryker restore all
 
     // Stryker disable all
-    const { data: userCommonsProfits } = useBackend(
+    const { data: userCommonsProfits } = useBackendConsole(
         [`/api/profits/all/commonsid?commonsId=${commonsId}`],
         {
             method: "GET",

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -49,6 +49,30 @@ export function useBackend(queryKey, axiosParameters, initialData, rest) {
         });
 }
 
+export function useBackendConsole(queryKey, axiosParameters, initialData, rest) {
+
+    return useQuery({
+        queryKey: queryKey,
+        queryFn: async () => {
+            try {
+                const response = await axios(axiosParameters);
+                return response.data;
+            } catch (e) {
+                // Stryker disable next-line OptionalChaining
+                if (e.response?.data?.message) {
+                    console.log(e.response.data.message);
+                } else {
+                    const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
+                    toast.error(errorMessage);
+                }
+                throw e;
+            }
+        }, 
+        initialData: initialData,
+        ...rest
+        });
+}
+
 const wrappedParams = async (params) => {
     return await (await axios(params)).data;
 };
@@ -76,4 +100,3 @@ export function useBackendMutation(objectToAxiosParams, useMutationParams, query
         ...useMutationParams
     })
 }
-


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, we disabled the Toast notifications and switched the errors to get logged to the browser console instead. We did this by going into useBackend.js and switching the toast.error to console.error instead.

New tests were made for useBackendConsole to account for mutation tests as well, and we edited PlayPage.js to use the new useBackendConsole instead of useBackend

## Screenshots (Optional)

<img width="1394" alt="Screen Shot 2024-05-29 at 10 05 58 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-5/assets/124761765/a3623ae6-436b-4c09-ba6a-891c9e014c01">

## Feedback Request (Optional)
I was thinking of disabling the Leaderboard and only showing the Access Denied page, but I'm not sure if I'd have to go dabble into the backend for this as I'm only editing PlayPage.js.



## Validation (Optional)

1. Visit https://happycows-nevetsle-dev.dokku-05.cs.ucsb.edu/
2. As an Admin, create a commons and join the first one. Then create a second one, one that you're not in.
3. enter "/play/#" after the URL (i.e. https://happycows-nevetsle-dev.dokku-05.cs.ucsb.edu/), # being the ID of a common you have not joined.
4. The Access Denied message should pop up with no toast notifications. If you right-click the browser and press Inspect, go to Console. The errors are still being logged by the application.

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #72 
